### PR TITLE
Check for existing custom target: uninstall

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,13 +86,15 @@ else()
     message(STATUS "Disabling tests")
 endif()
 
-# Confiugure the uninstall script
-configure_file(
-    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
-    "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
-    IMMEDIATE @ONLY
-)
+if(NOT TARGET uninstall)
+    # Confiugure the uninstall script
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+        IMMEDIATE @ONLY
+    )
 
-# Add uninstall target
-add_custom_target(uninstall
-    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+    # Add uninstall target
+    add_custom_target(uninstall
+        COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+endif()


### PR DESCRIPTION
When including `cppkafka` in a CMake project containing other project defining the same target (`curl`, specifically, which defines the same target [here](https://github.com/whoshuu/curl/blob/3ea76790571c1f7cf1bed34fabffd3cc20ad3dd3/CMakeLists.txt#L1293)) I get the foollowing error:

```
add_custom_target cannot create target "uninstall" because another target  with the same name already exists
```

This if condition fixes the issue.