### PR TITLE
destruct callbacks (and their closures)

### DIFF
--- a/src/consumer.cpp
+++ b/src/consumer.cpp
@@ -66,6 +66,11 @@ Consumer::Consumer(Configuration config)
 
 Consumer::~Consumer() {
     try {
+        // make sure to destroy the function closures. in case they hold kafka
+        // objects, they will need to be destroyed before we destroy the handle
+        assignment_callback_ = nullptr;
+        revocation_callback_ = nullptr;
+        rebalance_error_callback_ = nullptr;
         close();
     }
     catch (const Exception&) {


### PR DESCRIPTION
 to ensure there are no reference cycles to rd_kafka objects when destructing the consumer. This solves a potential hang in rd_kafka_destroy().
Here's a related ticket leading me to this patch: https://github.com/edenhill/librdkafka/issues/1117