### PR TITLE
Fixed deprecated error function call

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ ${RDKAFKA_ROOT_DIR}/
 ```
 
 By default, a shared library will be built. If you want to perform a static build,
-use the _CPPKAFKA_BUILD_SHARED_ parameter:
+use the `CPPKAFKA_BUILD_SHARED` parameter:
 
 ```Shell
 cmake .. -DCPPKAFKA_BUILD_SHARED=0

--- a/README.md
+++ b/README.md
@@ -76,9 +76,15 @@ If you have installed _librdkafka_ on a non standard directory, you can use the
 cmake .. -DRDKAFKA_ROOT_DIR=/some/other/dir
 ```
 
-Note that finding _librdkafka_ will succeed iff there's an _include_ and _lib_
-directories inside the specified path, including both the _rdkafka.h_ header
-and the _librdkafka_ library file.
+Note that the **RDKAFKA_ROOT_DIR** must contain the following structure:
+
+```Shell
+${RDKAFKA_ROOT_DIR}/
+                   |
+                   + include/librdkafka/rdkafka.h
+                   |
+                   + lib/librdkafka.a
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ If you have installed _librdkafka_ on a non standard directory, you can use the
 cmake .. -DRDKAFKA_ROOT_DIR=/some/other/dir
 ```
 
-Note that the **RDKAFKA_ROOT_DIR** must contain the following structure:
+Note that the `RDKAFKA_ROOT_DIR` must contain the following structure:
 
 ```Shell
 ${RDKAFKA_ROOT_DIR}/
@@ -85,8 +85,6 @@ ${RDKAFKA_ROOT_DIR}/
                    |
                    + lib/librdkafka.a
 ```
-
----
 
 By default, a shared library will be built. If you want to perform a static build,
 use the _CPPKAFKA_BUILD_SHARED_ parameter:

--- a/src/kafka_handle_base.cpp
+++ b/src/kafka_handle_base.cpp
@@ -172,7 +172,7 @@ void KafkaHandleBase::set_handle(rd_kafka_t* handle) {
 Topic KafkaHandleBase::get_topic(const string& name, rd_kafka_topic_conf_t* conf) {
     rd_kafka_topic_t* topic = rd_kafka_topic_new(get_handle(), name.data(), conf);
     if (!topic) {
-        throw HandleException(rd_kafka_errno2err(errno));
+        throw HandleException(rd_kafka_last_error());
     }
     return Topic(topic);
 }


### PR DESCRIPTION
Description of changes:
- Replaced rd_kafka_errno2err(errno) with rd_kafka_last_error()
- Added some clarifications in the README.md