### PR TITLE
Added cmake option for disabling tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
 
 # Build output checks
 option(CPPKAFKA_BUILD_SHARED "Build cppkafka as a shared library." ON)
-option(CPPKAFKA_BUILD_TESTS "Build cppkafka tests." ON)
+option(CPPKAKFA_DISABLE_TESTS "Build cppkafka tests." OFF)
 if(CPPKAFKA_BUILD_SHARED)
     message(STATUS "Build will generate a shared library. "
             "Use CPPKAFKA_BUILD_SHARED=0 to perform a static build")
@@ -61,7 +61,7 @@ if(DOXYGEN_FOUND)
     )
 endif(DOXYGEN_FOUND)
 
-if(CPPKAFKA_BUILD_TESTS)
+if(NOT CPPKAKFA_DISABLE_TESTS)
     set(GOOGLETEST_ROOT ${CMAKE_SOURCE_DIR}/third_party/googletest)
     if(EXISTS "${GOOGLETEST_ROOT}/CMakeLists.txt")
         set(GOOGLETEST_INCLUDE ${GOOGLETEST_ROOT}/googletest/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
 
 # Build output checks
 option(CPPKAFKA_BUILD_SHARED "Build cppkafka as a shared library." ON)
-option(CPPKAKFA_DISABLE_TESTS "Build cppkafka tests." OFF)
+option(CPPKAKFA_DISABLE_TESTS "Disable build of cppkafka tests." OFF)
 if(CPPKAFKA_BUILD_SHARED)
     message(STATUS "Build will generate a shared library. "
             "Use CPPKAFKA_BUILD_SHARED=0 to perform a static build")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
 
 # Build output checks
 option(CPPKAFKA_BUILD_SHARED "Build cppkafka as a shared library." ON)
+option(CPPKAFKA_BUILD_TESTS "Build cppkafka tests." ON)
 if(CPPKAFKA_BUILD_SHARED)
     message(STATUS "Build will generate a shared library. "
             "Use CPPKAFKA_BUILD_SHARED=0 to perform a static build")
@@ -60,30 +61,32 @@ if(DOXYGEN_FOUND)
     )
 endif(DOXYGEN_FOUND)
 
-set(GOOGLETEST_ROOT ${CMAKE_SOURCE_DIR}/third_party/googletest)
-if(EXISTS "${GOOGLETEST_ROOT}/CMakeLists.txt")
-    set(GOOGLETEST_INCLUDE ${GOOGLETEST_ROOT}/googletest/include)
-    set(GOOGLETEST_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/googletest)
-    set(GOOGLETEST_LIBRARY ${GOOGLETEST_BINARY_DIR}/googletest)
+if(CPPKAFKA_BUILD_TESTS)
+    set(GOOGLETEST_ROOT ${CMAKE_SOURCE_DIR}/third_party/googletest)
+    if(EXISTS "${GOOGLETEST_ROOT}/CMakeLists.txt")
+        set(GOOGLETEST_INCLUDE ${GOOGLETEST_ROOT}/googletest/include)
+        set(GOOGLETEST_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/googletest)
+        set(GOOGLETEST_LIBRARY ${GOOGLETEST_BINARY_DIR}/googletest)
 
-    include(ExternalProject)
+        include(ExternalProject)
 
-    ExternalProject_Add(
-      googletest
-      DOWNLOAD_COMMAND ""
-      SOURCE_DIR ${GOOGLETEST_ROOT}
-      BINARY_DIR ${GOOGLETEST_BINARY_DIR}
-      CMAKE_CACHE_ARGS "-DBUILD_GTEST:bool=ON" "-DBUILD_GMOCK:bool=OFF"
-                       "-Dgtest_force_shared_crt:bool=ON"
-      INSTALL_COMMAND ""
-    )
+        ExternalProject_Add(
+        googletest
+        DOWNLOAD_COMMAND ""
+        SOURCE_DIR ${GOOGLETEST_ROOT}
+        BINARY_DIR ${GOOGLETEST_BINARY_DIR}
+        CMAKE_CACHE_ARGS "-DBUILD_GTEST:bool=ON" "-DBUILD_GMOCK:bool=OFF"
+                        "-Dgtest_force_shared_crt:bool=ON"
+        INSTALL_COMMAND ""
+        )
 
-    enable_testing()
-    add_subdirectory(tests)
-    # Make sure we build googletest before anything else
-    add_dependencies(cppkafka googletest)
-else()
-    message(STATUS "Disabling tests")
+        enable_testing()
+        add_subdirectory(tests)
+        # Make sure we build googletest before anything else
+        add_dependencies(cppkafka googletest)
+    else()
+        message(STATUS "Disabling tests because submodule googletest isn't pulled out")
+    endif()
 endif()
 
 if(NOT TARGET uninstall)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
 
 # Build output checks
 option(CPPKAFKA_BUILD_SHARED "Build cppkafka as a shared library." ON)
-option(CPPKAKFA_DISABLE_TESTS "Disable build of cppkafka tests." OFF)
+option(CPPKAFKA_DISABLE_TESTS "Disable build of cppkafka tests." OFF)
 if(CPPKAFKA_BUILD_SHARED)
     message(STATUS "Build will generate a shared library. "
             "Use CPPKAFKA_BUILD_SHARED=0 to perform a static build")
@@ -61,7 +61,7 @@ if(DOXYGEN_FOUND)
     )
 endif(DOXYGEN_FOUND)
 
-if(NOT CPPKAKFA_DISABLE_TESTS)
+if(NOT CPPKAFKA_DISABLE_TESTS)
     set(GOOGLETEST_ROOT ${CMAKE_SOURCE_DIR}/third_party/googletest)
     if(EXISTS "${GOOGLETEST_ROOT}/CMakeLists.txt")
         set(GOOGLETEST_INCLUDE ${GOOGLETEST_ROOT}/googletest/include)


### PR DESCRIPTION
It's useful to have an option for disabling tests when building on CI server.

# Use Case:

* Imagine you have a project which uses cppkafka as a submodule
* You build project with CI server and for full-source build you do a git checkout with a recursive submodule update
* Now after checkout you have googletest submodule also cheсked out and cppkafla will be doing a tests build
* But as a submodule, cppkafka is always checked out on one specified commit and this means it's code is unchanged and stable. So it doesn't require any continuous testing.
* Having cppkafka tests built on your daily builds all you have is a time waste

This PR introduces CMake option CPPKAFKA_BUILD_TESTS which is enabled by default and old behavior is untouched. But it's easy to disable building tests with this option.
