### PR TITLE
Added commit for current assignment and message state checks

### DIFF
--- a/include/cppkafka/consumer.h
+++ b/include/cppkafka/consumer.h
@@ -98,8 +98,11 @@ class TopicConfiguration;
 class CPPKAFKA_API Consumer : public KafkaHandleBase {
 public:
     using AssignmentCallback = std::function<void(TopicPartitionList&)>;
+    using PartitionAssignmentCallback = std::function<void(Consumer&, TopicPartitionList&)>;
     using RevocationCallback = std::function<void(const TopicPartitionList&)>;
+    using PartitionRevocationCallback = std::function<void(Consumer&, const TopicPartitionList&)>;
     using RebalanceErrorCallback = std::function<void(Error)>;
+    using PartitionRebalanceErrorCallback = std::function<void(Consumer&, Error)>;
 
     /**
      * \brief Creates an instance of a consumer.
@@ -134,6 +137,11 @@ public:
      *
      * \param callback The topic/partition assignment callback
      */
+    void set_partition_assignment_callback(PartitionAssignmentCallback callback);
+    
+    /**
+     * @remark Deprecated. Use set_partition_assignment_callback()
+     */
     void set_assignment_callback(AssignmentCallback callback);
 
     /**
@@ -149,6 +157,11 @@ public:
      *
      * \param callback The topic/partition revocation callback
      */
+    void set_partition_revocation_callback(PartitionRevocationCallback callback);
+    
+    /**
+     * @remark Deprecated. Use set_partition_revocation_callback()
+     */
     void set_revocation_callback(RevocationCallback callback);
 
     /**
@@ -159,6 +172,11 @@ public:
      * and executing the assignment/revocation/rebalance_error callbacks.
      *
      * \param callback The rebalance error callback
+     */
+    void set_partition_rebalance_error_callback(PartitionRebalanceErrorCallback callback);
+    
+    /**
+     * @remark Deprecated. Use set_partition_rebalance_error_callback().
      */
     void set_rebalance_error_callback(RebalanceErrorCallback callback);
 
@@ -298,15 +316,30 @@ public:
     /**
      * Gets the partition assignment callback.
      */
+    const PartitionAssignmentCallback& get_partition_assignment_callback() const;
+    
+    /**
+     * @remark Legacy. Use get_partition_assignment_callback()
+     */
     const AssignmentCallback& get_assignment_callback() const;
 
     /**
      * Gets the partition revocation callback.
      */
+    const PartitionRevocationCallback& get_partition_revocation_callback() const;
+    
+    /**
+     * @remark Legacy. Use get_partition_revocation_callback()
+     */
     const RevocationCallback& get_revocation_callback() const;
 
     /**
      * Gets the rebalance error callback.
+     */
+    const PartitionRebalanceErrorCallback& get_partition_rebalance_error_callback() const;
+    
+    /**
+     * @remark Legacy. Use get_partition_rebalance_error_callback()
      */
     const RebalanceErrorCallback& get_rebalance_error_callback() const;
 
@@ -370,9 +403,12 @@ private:
     void commit(const TopicPartitionList* topic_partitions, bool async);
     void handle_rebalance(rd_kafka_resp_err_t err, TopicPartitionList& topic_partitions);
 
-    AssignmentCallback assignment_callback_;
-    RevocationCallback revocation_callback_;
-    RebalanceErrorCallback rebalance_error_callback_;
+    AssignmentCallback assignment_callback_;    //legacy
+    PartitionAssignmentCallback partition_assignment_callback_;
+    RevocationCallback revocation_callback_;    //legacy
+    PartitionRevocationCallback partition_revocation_callback_;
+    RebalanceErrorCallback rebalance_error_callback_; //legacy
+    PartitionRebalanceErrorCallback partition_rebalance_error_callback_;
 };
 
 } // cppkafka

--- a/include/cppkafka/consumer.h
+++ b/include/cppkafka/consumer.h
@@ -64,14 +64,14 @@ class TopicConfiguration;
  * Consumer consumer(config);
  *
  * // Set the assignment callback
- * consumer.set_assignment_callback([&](vector<TopicPartition>& topic_partitions) {
+ * consumer.set_assignment_callback([&](TopicPartitionList& topic_partitions) {
  *     // Here you could fetch offsets and do something, altering the offsets on the
  *     // topic_partitions vector if needed
  *     cout << "Got assigned " << topic_partitions.size() << " partitions!" << endl;
  * });
  *
  * // Set the revocation callback
- * consumer.set_revocation_callback([&](const vector<TopicPartition>& topic_partitions) {
+ * consumer.set_revocation_callback([&](const TopicPartitionList& topic_partitions) {
  *     cout << topic_partitions.size() << " partitions revoked!" << endl;
  * });
  * 
@@ -126,7 +126,7 @@ public:
      * \brief Sets the topic/partition assignment callback
      * 
      * The Consumer class will use rd_kafka_conf_set_rebalance_cb and will handle the
-     * rebalance, converting from rdkafka topic partition list handles into vector<TopicPartition>
+     * rebalance, converting from rdkafka topic partition list handles into TopicPartitionList
      * and executing the assignment/revocation/rebalance_error callbacks.
      *
      * \note You *do not need* to call Consumer::assign with the provided topic parttitions. This
@@ -140,7 +140,7 @@ public:
      * \brief Sets the topic/partition revocation callback
      * 
      * The Consumer class will use rd_kafka_conf_set_rebalance_cb and will handle the
-     * rebalance, converting from rdkafka topic partition list handles into vector<TopicPartition>
+     * rebalance, converting from rdkafka topic partition list handles into TopicPartitionList
      * and executing the assignment/revocation/rebalance_error callbacks.
      *
      * \note You *do not need* to call Consumer::assign with an empty topic partition list or
@@ -155,7 +155,7 @@ public:
      * \brief Sets the rebalance error callback
      * 
      * The Consumer class will use rd_kafka_conf_set_rebalance_cb and will handle the
-     * rebalance, converting from rdkafka topic partition list handles into vector<TopicPartition>
+     * rebalance, converting from rdkafka topic partition list handles into TopicPartitionList
      * and executing the assignment/revocation/rebalance_error callbacks.
      *
      * \param callback The rebalance error callback
@@ -192,6 +192,24 @@ public:
      * parameter
      */ 
     void unassign();
+    
+    /**
+     * \brief Commits the current partition assignment
+     *
+     * This translates into a call to rd_kafka_commit with a null partition list.
+     *
+     * \remark This function is similar to calling commit(get_assignment())
+     */
+    void commit();
+    
+    /**
+     * \brief Commits the current partition assignment asynchronously
+     *
+     * This translates into a call to rd_kafka_commit with a null partition list.
+     *
+     * \remark This function is similar to calling async_commit(get_assignment())
+     */
+    void async_commit();
 
     /**
      * \brief Commits the given message synchronously
@@ -349,7 +367,7 @@ private:
 
     void close();
     void commit(const Message& msg, bool async);
-    void commit(const TopicPartitionList& topic_partitions, bool async);
+    void commit(const TopicPartitionList* topic_partitions, bool async);
     void handle_rebalance(rd_kafka_resp_err_t err, TopicPartitionList& topic_partitions);
 
     AssignmentCallback assignment_callback_;

--- a/include/cppkafka/message.h
+++ b/include/cppkafka/message.h
@@ -38,6 +38,7 @@
 #include "buffer.h"
 #include "macros.h"
 #include "error.h"
+#include "exceptions.h"
 
 namespace cppkafka {
 
@@ -83,6 +84,9 @@ public:
      * Gets the error attribute
      */
     Error get_error() const {
+        if (!handle_) {
+            throw HandleException(RD_KAFKA_RESP_ERR__STATE);
+        }
         return handle_->err;
     }
 
@@ -97,6 +101,9 @@ public:
      * Gets the topic that this message belongs to
      */
     std::string get_topic() const {
+        if (!handle_) {
+            throw HandleException(RD_KAFKA_RESP_ERR__STATE);
+        }
         return rd_kafka_topic_name(handle_->rkt);
     }
 
@@ -104,6 +111,9 @@ public:
      * Gets the partition that this message belongs to
      */
     int get_partition() const {
+        if (!handle_) {
+            throw HandleException(RD_KAFKA_RESP_ERR__STATE);
+        }
         return handle_->partition;
     }
 
@@ -125,6 +135,9 @@ public:
      * Gets the message offset
      */
     int64_t get_offset() const {
+        if (!handle_) {
+            throw HandleException(RD_KAFKA_RESP_ERR__STATE);
+        }
         return handle_->offset;
     }
 
@@ -135,6 +148,9 @@ public:
      * attribute 
      */
     void* get_user_data() const {
+        if (!handle_) {
+            throw HandleException(RD_KAFKA_RESP_ERR__STATE);
+        }
         return handle_->_private;
     }
 

--- a/include/cppkafka/topic_partition_list.h
+++ b/include/cppkafka/topic_partition_list.h
@@ -49,9 +49,9 @@ using TopicPartitionsListPtr = std::unique_ptr<rd_kafka_topic_partition_list_t,
 using TopicPartitionList = std::vector<TopicPartition>;
 
 // Conversions between rdkafka handles and TopicPartitionList
-CPPKAFKA_API TopicPartitionsListPtr convert(const std::vector<TopicPartition>& topic_partitions);
-CPPKAFKA_API std::vector<TopicPartition> convert(const TopicPartitionsListPtr& topic_partitions);
-CPPKAFKA_API std::vector<TopicPartition> convert(rd_kafka_topic_partition_list_t* topic_partitions);
+CPPKAFKA_API TopicPartitionsListPtr convert(const TopicPartitionList& topic_partitions);
+CPPKAFKA_API TopicPartitionList convert(const TopicPartitionsListPtr& topic_partitions);
+CPPKAFKA_API TopicPartitionList convert(rd_kafka_topic_partition_list_t* topic_partitions);
 CPPKAFKA_API TopicPartitionsListPtr make_handle(rd_kafka_topic_partition_list_t* handle);
 
 CPPKAFKA_API std::ostream& operator<<(std::ostream& output, const TopicPartitionList& rhs);

--- a/src/consumer.cpp
+++ b/src/consumer.cpp
@@ -116,6 +116,14 @@ void Consumer::unassign() {
     check_error(error);
 }
 
+void Consumer::commit() {
+    commit(nullptr, false);
+}
+
+void Consumer::async_commit() {
+    commit(nullptr, true);
+}
+
 void Consumer::commit(const Message& msg) {
     commit(msg, false);
 }
@@ -125,11 +133,11 @@ void Consumer::async_commit(const Message& msg) {
 }
 
 void Consumer::commit(const TopicPartitionList& topic_partitions) {
-    commit(topic_partitions, false);
+    commit(&topic_partitions, false);
 }
 
 void Consumer::async_commit(const TopicPartitionList& topic_partitions) {
-    commit(topic_partitions, true);
+    commit(&topic_partitions, true);
 }
 
 KafkaHandleBase::OffsetTuple Consumer::get_offsets(const TopicPartition& topic_partition) const {
@@ -238,15 +246,15 @@ void Consumer::close() {
 
 void Consumer::commit(const Message& msg, bool async) {
     rd_kafka_resp_err_t error;
-    error = rd_kafka_commit_message(get_handle(), msg.get_handle(),
-                                    async ? 1 : 0);
+    error = rd_kafka_commit_message(get_handle(), msg.get_handle(), async);
     check_error(error);
 }
 
-void Consumer::commit(const TopicPartitionList& topic_partitions, bool async) {
-    TopicPartitionsListPtr topic_list_handle = convert(topic_partitions);
+void Consumer::commit(const TopicPartitionList* topic_partitions, bool async) {
     rd_kafka_resp_err_t error;
-    error = rd_kafka_commit(get_handle(), topic_list_handle.get(), async ? 1 : 0);
+    error = rd_kafka_commit(get_handle(),
+                            !topic_partitions ? nullptr : convert(*topic_partitions).get(),
+                            async);
     check_error(error);
 }
 

--- a/src/consumer.cpp
+++ b/src/consumer.cpp
@@ -83,12 +83,24 @@ void Consumer::set_assignment_callback(AssignmentCallback callback) {
     assignment_callback_ = move(callback);
 }
 
+void Consumer::set_partition_assignment_callback(PartitionAssignmentCallback callback) {
+    partition_assignment_callback_ = move(callback);
+}
+
 void Consumer::set_revocation_callback(RevocationCallback callback) {
     revocation_callback_ = move(callback);
 }
 
+void Consumer::set_partition_revocation_callback(PartitionRevocationCallback callback) {
+    partition_revocation_callback_ = move(callback);
+}
+
 void Consumer::set_rebalance_error_callback(RebalanceErrorCallback callback) {
     rebalance_error_callback_ = move(callback);
+}
+
+void Consumer::set_partition_rebalance_error_callback(PartitionRebalanceErrorCallback callback) {
+    partition_rebalance_error_callback_ = move(callback);
 }
 
 void Consumer::subscribe(const vector<string>& topics) {
@@ -198,12 +210,24 @@ const Consumer::AssignmentCallback& Consumer::get_assignment_callback() const {
     return assignment_callback_;
 }
 
+const Consumer::PartitionAssignmentCallback& Consumer::get_partition_assignment_callback() const {
+    return partition_assignment_callback_;
+}
+
 const Consumer::RevocationCallback& Consumer::get_revocation_callback() const {
     return revocation_callback_;
 }
 
+const Consumer::PartitionRevocationCallback& Consumer::get_partition_revocation_callback() const {
+    return partition_revocation_callback_;
+}
+
 const Consumer::RebalanceErrorCallback& Consumer::get_rebalance_error_callback() const {
     return rebalance_error_callback_;
+}
+
+const Consumer::PartitionRebalanceErrorCallback& Consumer::get_partition_rebalance_error_callback() const {
+    return partition_rebalance_error_callback_;
 }
 
 Message Consumer::poll() {
@@ -261,19 +285,28 @@ void Consumer::commit(const TopicPartitionList* topic_partitions, bool async) {
 void Consumer::handle_rebalance(rd_kafka_resp_err_t error,
                                 TopicPartitionList& topic_partitions) {
     if (error == RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS) {
-        if (assignment_callback_) {
+        if (partition_assignment_callback_) {
+            partition_assignment_callback_(*this, topic_partitions);
+        }
+        else if (assignment_callback_) {
             assignment_callback_(topic_partitions);
         }
         assign(topic_partitions);
     }
     else if (error == RD_KAFKA_RESP_ERR__REVOKE_PARTITIONS) {
-        if (revocation_callback_) {
+        if (partition_revocation_callback_) {
+            partition_revocation_callback_(*this, topic_partitions);
+        }
+        else if (revocation_callback_) {
             revocation_callback_(topic_partitions);
         }
         unassign();
     }
     else {
-        if (rebalance_error_callback_) {
+        if (partition_rebalance_error_callback_) {
+            partition_rebalance_error_callback_(*this, error);
+        }
+        else if (rebalance_error_callback_) {
             rebalance_error_callback_(error);
         }
         unassign();

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -41,7 +41,7 @@ Message Message::make_non_owning(rd_kafka_message_t* handle) {
     return Message(handle, NonOwningTag());
 }
 
-Message::Message() 
+Message::Message()
 : handle_(nullptr, nullptr) {
 
 }

--- a/src/topic_partition_list.cpp
+++ b/src/topic_partition_list.cpp
@@ -37,7 +37,7 @@ using std::ostream;
 
 namespace cppkafka {
 
-TopicPartitionsListPtr convert(const vector<TopicPartition>& topic_partitions) {
+TopicPartitionsListPtr convert(const TopicPartitionList& topic_partitions) {
     TopicPartitionsListPtr handle(rd_kafka_topic_partition_list_new(topic_partitions.size()),
                                   &rd_kafka_topic_partition_list_destroy);
     for (const auto& item : topic_partitions) {
@@ -50,12 +50,12 @@ TopicPartitionsListPtr convert(const vector<TopicPartition>& topic_partitions) {
     return handle;
 }
 
-vector<TopicPartition> convert(const TopicPartitionsListPtr& topic_partitions) {
+TopicPartitionList convert(const TopicPartitionsListPtr& topic_partitions) {
     return convert(topic_partitions.get());
 }
 
-vector<TopicPartition> convert(rd_kafka_topic_partition_list_t* topic_partitions) {
-    vector<TopicPartition> output;
+TopicPartitionList convert(rd_kafka_topic_partition_list_t* topic_partitions) {
+    TopicPartitionList output;
     for (int i = 0; i < topic_partitions->cnt; ++i) {
         const auto& elem = topic_partitions->elems[i];
         output.emplace_back(elem.topic, elem.partition, elem.offset);

--- a/tests/consumer_test.cpp
+++ b/tests/consumer_test.cpp
@@ -51,12 +51,12 @@ public:
 const string ConsumerTest::KAFKA_TOPIC = "cppkafka_test1";
 
 TEST_F(ConsumerTest, AssignmentCallback) {
-    vector<TopicPartition> assignment;
+    TopicPartitionList assignment;
     int partition = 0;
 
     // Create a consumer and subscribe to the topic
     Consumer consumer(make_consumer_config());
-    consumer.set_assignment_callback([&](const vector<TopicPartition>& topic_partitions) {
+    consumer.set_assignment_callback([&](const TopicPartitionList& topic_partitions) {
         assignment = topic_partitions;
     });
     consumer.subscribe({ KAFKA_TOPIC });
@@ -90,17 +90,17 @@ TEST_F(ConsumerTest, AssignmentCallback) {
 }
 
 TEST_F(ConsumerTest, Rebalance) {
-    vector<TopicPartition> assignment1;
-    vector<TopicPartition> assignment2;
+    TopicPartitionList assignment1;
+    TopicPartitionList assignment2;
     bool revocation_called = false;
     int partition = 0;
 
     // Create a consumer and subscribe to the topic
     Consumer consumer1(make_consumer_config());
-    consumer1.set_assignment_callback([&](const vector<TopicPartition>& topic_partitions) {
+    consumer1.set_assignment_callback([&](const TopicPartitionList& topic_partitions) {
         assignment1 = topic_partitions;
     });
-    consumer1.set_revocation_callback([&](const vector<TopicPartition>&) {
+    consumer1.set_revocation_callback([&](const TopicPartitionList&) {
         revocation_called = true;
     });
     consumer1.subscribe({ KAFKA_TOPIC });
@@ -108,7 +108,7 @@ TEST_F(ConsumerTest, Rebalance) {
 
     // Create a second consumer and subscribe to the topic
     Consumer consumer2(make_consumer_config());
-    consumer2.set_assignment_callback([&](const vector<TopicPartition>& topic_partitions) {
+    consumer2.set_assignment_callback([&](const TopicPartitionList& topic_partitions) {
         assignment2 = topic_partitions;
     });
     consumer2.subscribe({ KAFKA_TOPIC });

--- a/tests/kafka_handle_base_test.cpp
+++ b/tests/kafka_handle_base_test.cpp
@@ -126,12 +126,12 @@ TEST_F(KafkaHandleBaseTest, ConsumerGroups) {
 
     MemberAssignmentInformation assignment = member.get_member_assignment();
     EXPECT_EQ(0, assignment.get_version());
-    vector<TopicPartition> expected_topic_partitions = {
+    TopicPartitionList expected_topic_partitions = {
         { KAFKA_TOPIC, 0 },
         { KAFKA_TOPIC, 1 },
         { KAFKA_TOPIC, 2 }
     };
-    vector<TopicPartition> topic_partitions = assignment.get_topic_partitions();
+    TopicPartitionList topic_partitions = assignment.get_topic_partitions();
     sort(topic_partitions.begin(), topic_partitions.end());
     EXPECT_EQ(expected_topic_partitions, topic_partitions);
     /*for (const auto c : ) {


### PR DESCRIPTION
### Description

* Added `commit()` and `async_commit()` methods in the consumer class for committing on the current partition assignment. This is supported directly by librdkafka api. 
* Added null handle checks in the `Message` class.
* Changed `std::vector<TopicPartition>` -> `TopicPartitionList` alias for consistency in the code.
* Added Consumer object reference in partition assignment callbacks. This allows access to the object being re-assigned and is more consistent with all other callbacks which pass-in Producer or KafkaHandleBase as first parameter. 