### PR TITLE
Print offset when dumping partition object

### DIFF
--- a/src/topic_partition.cpp
+++ b/src/topic_partition.cpp
@@ -33,6 +33,7 @@
 #include "topic_partition.h"
 
 using std::string;
+using std::to_string;
 using std::ostream;
 using std::tie;
 
@@ -92,7 +93,10 @@ bool TopicPartition::operator!=(const TopicPartition& rhs) const {
 }
 
 ostream& operator<<(ostream& output, const TopicPartition& rhs) {
-    return output << rhs.get_topic() << "[" << rhs.get_partition() << "]";
+    return output << rhs.get_topic() << "["
+                  << rhs.get_partition() << ":"
+                  << (rhs.get_offset() == RD_KAFKA_OFFSET_INVALID ? "#" : to_string(rhs.get_offset()))
+                  << "]";
 }
 
 } // cppkafka

--- a/tests/topic_partition_list_test.cpp
+++ b/tests/topic_partition_list_test.cpp
@@ -34,7 +34,7 @@ TEST_F(TopicPartitionListTest, AsString) {
     ostringstream output;
     TopicPartition topic_partition("foo", 5);
     output << topic_partition;
-    EXPECT_EQ("foo[5]", output.str());
+    EXPECT_EQ("foo[5:#]", output.str());
 }
 
 TEST_F(TopicPartitionListTest, ListAsString) {
@@ -42,7 +42,8 @@ TEST_F(TopicPartitionListTest, ListAsString) {
     TopicPartitionList list;
     list.push_back("foo");
     list.push_back({ "bar", 2 });
+    list.push_back({ "foobar", 3, 4 });
 
     output << list;
-    EXPECT_EQ("[ foo[-1], bar[2] ]", output.str());
+    EXPECT_EQ("[ foo[-1:#], bar[2:#], foobar[3:4] ]", output.str());
 }


### PR DESCRIPTION
Print offset as part of the partition stream out. If offset is invalid print `#` 