### PR TITLE
Add yield

### DIFF
--- a/include/cppkafka/kafka_handle_base.h
+++ b/include/cppkafka/kafka_handle_base.h
@@ -200,6 +200,13 @@ public:
      * This calls rd_kafka_outq_len
      */
     int get_out_queue_length() const;
+
+    /**
+     * \brief Cancels the current callback dispatcher
+     *
+     * This calls rd_kafka_yield
+     */
+    void yield() const;
 protected:
     KafkaHandleBase(Configuration config);
 

--- a/src/kafka_handle_base.cpp
+++ b/src/kafka_handle_base.cpp
@@ -165,6 +165,10 @@ int KafkaHandleBase::get_out_queue_length() const {
     return rd_kafka_outq_len(handle_.get());
 }
 
+void KafkaHandleBase::yield() const {
+    rd_kafka_yield(handle_.get());
+}
+
 void KafkaHandleBase::set_handle(rd_kafka_t* handle) {
     handle_ = HandlePtr(handle, &rd_kafka_destroy);
 }


### PR DESCRIPTION
Simply calls rd_kafka_yield; allows consumers and producers to abort the
current callback dispatcher.