### PR TITLE
Pause/resume a consumer by topic

### DIFF
--- a/include/cppkafka/consumer.h
+++ b/include/cppkafka/consumer.h
@@ -194,6 +194,30 @@ public:
     void unassign();
     
     /**
+     * \brief Pauses all consumption
+     */
+    void pause();
+    
+    /**
+     * \brief Pauses consumption from the given topic list
+     *
+     * \param List of topics
+     */
+    void pause_topics(const std::vector<std::string>& topics);
+    
+    /**
+     * \brief Resumes all consumption
+     */
+     void resume();
+     
+     /**
+     * \brief Resumes consumption from the given topic list
+     *
+     * \param List of topics
+     */
+    void resume_topics(const std::vector<std::string>& topics);
+    
+    /**
      * \brief Commits the current partition assignment
      *
      * This translates into a call to rd_kafka_commit with a null partition list.
@@ -364,6 +388,8 @@ public:
 private:
     static void rebalance_proxy(rd_kafka_t *handle, rd_kafka_resp_err_t error,
                                 rd_kafka_topic_partition_list_t *partitions, void *opaque);
+    static TopicPartitionList get_matching_partitions(TopicPartitionList&& partitions,
+                                                      const std::vector<std::string>& topics);
 
     void close();
     void commit(const Message& msg, bool async);

--- a/include/cppkafka/consumer.h
+++ b/include/cppkafka/consumer.h
@@ -199,23 +199,9 @@ public:
     void pause();
     
     /**
-     * \brief Pauses consumption from the given topic list
-     *
-     * \param List of topics
-     */
-    void pause_topics(const std::vector<std::string>& topics);
-    
-    /**
      * \brief Resumes all consumption
      */
      void resume();
-     
-     /**
-     * \brief Resumes consumption from the given topic list
-     *
-     * \param List of topics
-     */
-    void resume_topics(const std::vector<std::string>& topics);
     
     /**
      * \brief Commits the current partition assignment
@@ -388,9 +374,6 @@ public:
 private:
     static void rebalance_proxy(rd_kafka_t *handle, rd_kafka_resp_err_t error,
                                 rd_kafka_topic_partition_list_t *partitions, void *opaque);
-    static TopicPartitionList get_matching_partitions(TopicPartitionList partitions,
-                                                      const std::vector<std::string>& topics);
-
     void close();
     void commit(const Message& msg, bool async);
     void commit(const TopicPartitionList* topic_partitions, bool async);

--- a/include/cppkafka/consumer.h
+++ b/include/cppkafka/consumer.h
@@ -388,7 +388,7 @@ public:
 private:
     static void rebalance_proxy(rd_kafka_t *handle, rd_kafka_resp_err_t error,
                                 rd_kafka_topic_partition_list_t *partitions, void *opaque);
-    static TopicPartitionList get_matching_partitions(TopicPartitionList&& partitions,
+    static TopicPartitionList get_matching_partitions(TopicPartitionList partitions,
                                                       const std::vector<std::string>& topics);
 
     void close();

--- a/include/cppkafka/topic_partition_list.h
+++ b/include/cppkafka/topic_partition_list.h
@@ -34,6 +34,7 @@
 #include <iosfwd>
 #include <algorithm>
 #include <vector>
+#include <set>
 #include <librdkafka/rdkafka.h>
 #include "macros.h"
 
@@ -55,14 +56,14 @@ CPPKAFKA_API TopicPartitionList convert(rd_kafka_topic_partition_list_t* topic_p
 CPPKAFKA_API TopicPartitionsListPtr make_handle(rd_kafka_topic_partition_list_t* handle);
 
 // Extracts a partition list subset belonging to the provided topics (case-insensitive)
-CPPKAFKA_API TopicPartitionList make_subset(const TopicPartitionList& partitions,
-                                            const std::vector<std::string>& topics);
+CPPKAFKA_API TopicPartitionList find_matches(const TopicPartitionList& partitions,
+                                             const std::set<std::string>& topics);
 
 // Extracts a partition list subset belonging to the provided partition ids
 // Note: this assumes that all topic partitions in the original list belong to the same topic
 //       otherwise the partition ids may not be unique
-CPPKAFKA_API TopicPartitionList make_subset(const TopicPartitionList& partitions,
-                                            const std::vector<int>& ids);
+CPPKAFKA_API TopicPartitionList find_matches(const TopicPartitionList& partitions,
+                                             const std::set<int>& ids);
 
 CPPKAFKA_API std::ostream& operator<<(std::ostream& output, const TopicPartitionList& rhs);
 

--- a/include/cppkafka/topic_partition_list.h
+++ b/include/cppkafka/topic_partition_list.h
@@ -54,6 +54,16 @@ CPPKAFKA_API TopicPartitionList convert(const TopicPartitionsListPtr& topic_part
 CPPKAFKA_API TopicPartitionList convert(rd_kafka_topic_partition_list_t* topic_partitions);
 CPPKAFKA_API TopicPartitionsListPtr make_handle(rd_kafka_topic_partition_list_t* handle);
 
+// Extracts a partition list subset belonging to the provided topics (case-insensitive)
+CPPKAFKA_API TopicPartitionList make_subset(const TopicPartitionList& partitions,
+                                            const std::vector<std::string>& topics);
+
+// Extracts a partition list subset belonging to the provided partition ids
+// Note: this assumes that all topic partitions in the original list belong to the same topic
+//       otherwise the partition ids may not be unique
+CPPKAFKA_API TopicPartitionList make_subset(const TopicPartitionList& partitions,
+                                            const std::vector<int>& ids);
+
 CPPKAFKA_API std::ostream& operator<<(std::ostream& output, const TopicPartitionList& rhs);
 
 } // cppkafka

--- a/src/consumer.cpp
+++ b/src/consumer.cpp
@@ -52,26 +52,6 @@ void Consumer::rebalance_proxy(rd_kafka_t*, rd_kafka_resp_err_t error,
     static_cast<Consumer*>(opaque)->handle_rebalance(error, list);
 }
 
-TopicPartitionList Consumer::get_matching_partitions(TopicPartitionList partitions,
-                                                     const vector<string>& topics) {
-    TopicPartitionList matches;
-    for (const auto& topic : topics) {
-        for (auto& partition : partitions) {
-            if (topic.size() == partition.get_topic().size()) {
-                // compare both strings
-                bool match = equal(topic.begin(), topic.end(), partition.get_topic().begin(),
-                                   [](char c1, char c2)->bool {
-                    return toupper(c1) == toupper(c2);
-                });
-                if (match) {
-                    matches.emplace_back(move(partition));
-                }
-            }
-        }
-    }
-    return matches;
-}
-
 Consumer::Consumer(Configuration config) 
 : KafkaHandleBase(move(config)) {
     char error_buffer[512];
@@ -153,16 +133,8 @@ void Consumer::pause() {
     pause_partitions(get_assignment());
 }
 
-void Consumer::pause_topics(const vector<string>& topics) {
-    pause_partitions(get_matching_partitions(get_assignment(), topics));
-}
-
 void Consumer::resume() {
     resume_partitions(get_assignment());
-}
-
-void Consumer::resume_topics(const vector<string>& topics) {
-    resume_partitions(get_matching_partitions(get_assignment(), topics));
 }
 
 void Consumer::commit() {

--- a/src/consumer.cpp
+++ b/src/consumer.cpp
@@ -57,6 +57,10 @@ TopicPartitionList Consumer::get_matching_partitions(TopicPartitionList&& partit
     TopicPartitionList matches;
     for (const auto& topic : topics) {
         for (auto& partition : partitions) {
+            if (topic.size() != partition.get_topic().size()) {
+                continue;
+            }
+            // compare both strings
             bool match = equal(topic.begin(), topic.end(), partition.get_topic().begin(),
                                [](char c1, char c2)->bool {
                 return toupper(c1) == toupper(c2);
@@ -150,7 +154,7 @@ void Consumer::pause() {
     pause_partitions(get_assignment());
 }
 
-void Consumer::pause_topics(const std::vector<string>& topics) {
+void Consumer::pause_topics(const vector<string>& topics) {
     pause_partitions(get_matching_partitions(get_assignment(), topics));
 }
 
@@ -158,7 +162,7 @@ void Consumer::resume() {
     resume_partitions(get_assignment());
 }
 
-void Consumer::resume_topics(const std::vector<string>& topics) {
+void Consumer::resume_topics(const vector<string>& topics) {
     resume_partitions(get_matching_partitions(get_assignment(), topics));
 }
 

--- a/src/consumer.cpp
+++ b/src/consumer.cpp
@@ -52,21 +52,20 @@ void Consumer::rebalance_proxy(rd_kafka_t*, rd_kafka_resp_err_t error,
     static_cast<Consumer*>(opaque)->handle_rebalance(error, list);
 }
 
-TopicPartitionList Consumer::get_matching_partitions(TopicPartitionList&& partitions,
+TopicPartitionList Consumer::get_matching_partitions(TopicPartitionList partitions,
                                                      const vector<string>& topics) {
     TopicPartitionList matches;
     for (const auto& topic : topics) {
         for (auto& partition : partitions) {
-            if (topic.size() != partition.get_topic().size()) {
-                continue;
-            }
-            // compare both strings
-            bool match = equal(topic.begin(), topic.end(), partition.get_topic().begin(),
-                               [](char c1, char c2)->bool {
-                return toupper(c1) == toupper(c2);
-            });
-            if (match) {
-                matches.emplace_back(move(partition));
+            if (topic.size() == partition.get_topic().size()) {
+                // compare both strings
+                bool match = equal(topic.begin(), topic.end(), partition.get_topic().begin(),
+                                   [](char c1, char c2)->bool {
+                    return toupper(c1) == toupper(c2);
+                });
+                if (match) {
+                    matches.emplace_back(move(partition));
+                }
             }
         }
     }

--- a/src/topic_partition_list.cpp
+++ b/src/topic_partition_list.cpp
@@ -94,11 +94,8 @@ TopicPartitionList find_matches(const TopicPartitionList& partitions,
                                 const set<int>& ids) {
     TopicPartitionList subset;
     for (const auto& partition : partitions) {
-        for (const auto& id : ids) {
-            // compare both partition ids
-            if (id == partition.get_partition()) {
-                subset.emplace_back(partition);
-            }
+        if (ids.count(partition.get_partition()) > 0) {
+            subset.emplace_back(partition);
         }
     }
     return subset;

--- a/tests/topic_partition_list_test.cpp
+++ b/tests/topic_partition_list_test.cpp
@@ -46,36 +46,42 @@ TEST_CASE("topic partition list to string", "[topic_partition]") {
 }
 
 TEST_CASE("find matches by topic", "[topic_partition]") {
-    TopicPartitionList list;
-    list.push_back({ "foo", 0 });
-    list.push_back({ "bar", 3 });
-    list.push_back({ "fb",  1 });
-    list.push_back({ "foo", 1 });
-    list.push_back({ "fb",  2 });
-    list.push_back({ "other", 1 });
-    list.push_back({ "a",   1 });
+    const TopicPartitionList list = {
+        { "foo", 0 },
+        { "bar", 3 },
+        { "fb",  1 },
+        { "foo", 1 },
+        { "fb",  2 },
+        { "other", 1 },
+        { "a",   1 }
+    };
 
-    TopicPartitionList subset = find_matches(list, set<string>{"foo", "fb"});
-    REQUIRE(subset.size() == 4);
-    CHECK((subset[0].get_topic() == "foo" && subset[0].get_partition() == 0));
-    CHECK((subset[1].get_topic() == "fb" && subset[1].get_partition() == 1));
-    CHECK((subset[2].get_topic() == "foo" && subset[2].get_partition() == 1));
-    CHECK((subset[3].get_topic() == "fb" && subset[3].get_partition() == 2));
+    const TopicPartitionList expected = {
+        { "foo", 0 },  
+        { "fb", 1 },
+        { "foo", 1 },
+        { "fb", 2 },
+    };
+    const TopicPartitionList subset = find_matches(list, set<string>{"foo", "fb"});
+    CHECK(subset == expected);
 }
 
 TEST_CASE("find matches by id", "[topic_partition]") {
-    TopicPartitionList list;
-    list.push_back({ "foo", 2 });
-    list.push_back({ "foo", 3 });
-    list.push_back({ "foo", 4 });
-    list.push_back({ "foo", 5 });
-    list.push_back({ "foo", 6 });
-    list.push_back({ "foo", 7 });
-    list.push_back({ "foo", 8 });
+    const TopicPartitionList list = {
+        { "foo", 2 },
+        { "foo", 3 },
+        { "foo", 4 },
+        { "foo", 5 },
+        { "foo", 6 },
+        { "foo", 7 },
+        { "foo", 8 }
+    };
 
-    TopicPartitionList subset = find_matches(list, set<int>{2,5,8});
-    REQUIRE(subset.size() == 3);
-    CHECK(subset[0].get_partition() == 2);
-    CHECK(subset[1].get_partition() == 5);
-    CHECK(subset[2].get_partition() == 8);
+    const TopicPartitionList expected = {
+        { "foo", 2 },
+        { "foo", 5 },
+        { "foo", 8 },
+    };
+    const TopicPartitionList subset = find_matches(list, set<int>{2,5,8});
+    CHECK(subset == expected);
 }


### PR DESCRIPTION
The base class `KafkaHandleBase` currently allows pausing/resuming by partitions which has fine granularity. In some use cases, the partitions are not really known or exposed to the application and furthermore, pausing/resuming action is mostly thought conceptually of at the topic level rather than at the partition level. These methods facilitate this.

Note: I debated whether or not these should go into the base class as well, but there are a few caveats with the producer. 
1) Pausing a producer can easily be done at the application level.
2) Producers can always produce to new topics (as long as they are on the registered broker list) ad-hoc and the partitioning is not available unless one queries the metadata from the brokers or uses a partitioning callback. Making this metadata call is fairly expensive and I'm not sure it's worth doing with each pause/resume. Metadata could be cached locally but this makes things more complicated. 
3) In the case where this is really needed, the base class method can be used.