### PR TITLE
Added access to the internal Consumer in the backoff committer

### DIFF
--- a/include/cppkafka/utils/backoff_committer.h
+++ b/include/cppkafka/utils/backoff_committer.h
@@ -75,7 +75,7 @@ public:
     /**
      * \brief The error callback.
      * 
-     * Whenever an error occurs comitting an offset, this callback will be executed using
+     * Whenever an error occurs committing an offset, this callback will be executed using
      * the generated error. While the function returns true, then this is offset will be
      * committed again until it either succeeds or the function returns false.
      */
@@ -89,6 +89,18 @@ public:
      * \param consumer The consumer to use for committing offsets
      */
     BackoffCommitter(Consumer& consumer);
+    
+    /**
+     * \brief Constructs an instance using specified values
+     *
+     * \sa BackoffPerformer::BackoffPerformer
+     */
+    BackoffCommitter(Consumer& consumer,
+                     TimeUnit initial_backoff,
+                     TimeUnit backoff_step,
+                     TimeUnit maximum_backoff,
+                     BackoffPolicy policy,
+                     size_t maximum_retries);
 
     /**
      * \brief Sets the error callback
@@ -97,8 +109,7 @@ public:
      * \param callback The callback to be set
      */
     void set_error_callback(ErrorCallback callback);
-
-
+    
     /**
      * \brief Commits the given message synchronously
      *
@@ -118,6 +129,13 @@ public:
      * \param topic_partitions The topic/partition list to be committed
      */
     void commit(const TopicPartitionList& topic_partitions);
+    
+    /**
+     * \brief Get the internal Consumer object
+     *
+     * \return A reference to the Consumer
+     */
+    Consumer& get_consumer();
 private:
     // Return true to abort and false to continue committing
     template <typename T>

--- a/include/cppkafka/utils/backoff_committer.h
+++ b/include/cppkafka/utils/backoff_committer.h
@@ -89,18 +89,6 @@ public:
      * \param consumer The consumer to use for committing offsets
      */
     BackoffCommitter(Consumer& consumer);
-    
-    /**
-     * \brief Constructs an instance using specified values
-     *
-     * \sa BackoffPerformer::BackoffPerformer
-     */
-    BackoffCommitter(Consumer& consumer,
-                     TimeUnit initial_backoff,
-                     TimeUnit backoff_step,
-                     TimeUnit maximum_backoff,
-                     BackoffPolicy policy,
-                     size_t maximum_retries);
 
     /**
      * \brief Sets the error callback

--- a/include/cppkafka/utils/backoff_performer.h
+++ b/include/cppkafka/utils/backoff_performer.h
@@ -57,11 +57,26 @@ public:
     };
 
     /**
-     * Constructs an instance of backoff perform
+     * Constructs an instance of backoff performer
      * 
      * By default, the linear backoff policy is used
      */
     BackoffPerformer();
+    
+    /**
+     * \brief Constructs an instance of backoff performer
+     *
+     * \param initial_backoff The initial backoff interval
+     * \param backoff_step The backoff step interval
+     * \param maximum_backoff The maximum backoff interval
+     * \param policy The backoff policy
+     * \param maximum_retries The max number of retries
+     */
+    BackoffPerformer(TimeUnit initial_backoff,
+                     TimeUnit backoff_step,
+                     TimeUnit maximum_backoff,
+                     BackoffPolicy policy,
+                     size_t maximum_retries);
 
     /**
      * \brief Sets the backoff policy

--- a/include/cppkafka/utils/backoff_performer.h
+++ b/include/cppkafka/utils/backoff_performer.h
@@ -62,21 +62,6 @@ public:
      * By default, the linear backoff policy is used
      */
     BackoffPerformer();
-    
-    /**
-     * \brief Constructs an instance of backoff performer
-     *
-     * \param initial_backoff The initial backoff interval
-     * \param backoff_step The backoff step interval
-     * \param maximum_backoff The maximum backoff interval
-     * \param policy The backoff policy
-     * \param maximum_retries The max number of retries
-     */
-    BackoffPerformer(TimeUnit initial_backoff,
-                     TimeUnit backoff_step,
-                     TimeUnit maximum_backoff,
-                     BackoffPolicy policy,
-                     size_t maximum_retries);
 
     /**
      * \brief Sets the backoff policy

--- a/include/cppkafka/utils/buffered_producer.h
+++ b/include/cppkafka/utils/buffered_producer.h
@@ -155,24 +155,6 @@ public:
      * \remark This method throws cppkafka::HandleException on failure
      */
     void produce(const Message& message);
-    
-    /**
-     * \brief Produces a message without buffering it and blocks until an ack is received
-     *
-     * \param builder The builder that contains the message to be produced
-     *
-     * \remark This method throws cppkafka::HandleException on failure
-     */
-    void sync_produce(const MessageBuilder& builder);
-    
-    /**
-     * \brief Produces a message without buffering it and blocks until an ack is received
-     *
-     * \param message The message to be produced
-     *
-     * \remark This method throws cppkafka::HandleException on failure
-     */
-    void sync_produce(const Message& message);
 
     /**
      * \brief Flushes the buffered messages.
@@ -367,18 +349,6 @@ void BufferedProducer<BufferType>::produce(const MessageBuilder& builder) {
 template <typename BufferType>
 void BufferedProducer<BufferType>::produce(const Message& message) {
     produce_message(message);
-}
-
-template <typename BufferType>
-void BufferedProducer<BufferType>::sync_produce(const MessageBuilder& builder) {
-    produce_message(builder);
-    wait_for_acks();
-}
-
-template <typename BufferType>
-void BufferedProducer<BufferType>::sync_produce(const Message& message) {
-    produce_message(message);
-    wait_for_acks();
 }
 
 template <typename BufferType>

--- a/src/utils/backoff_committer.cpp
+++ b/src/utils/backoff_committer.cpp
@@ -39,6 +39,17 @@ BackoffCommitter::BackoffCommitter(Consumer& consumer)
 
 }
 
+BackoffCommitter::BackoffCommitter(Consumer& consumer,
+                                   TimeUnit initial_backoff,
+                                   TimeUnit backoff_step,
+                                   TimeUnit maximum_backoff,
+                                   BackoffPolicy policy,
+                                   size_t maximum_retries)
+: BackoffPerformer(initial_backoff, backoff_step, maximum_backoff, policy, maximum_retries),
+  consumer_(consumer) {
+  
+}
+
 void BackoffCommitter::set_error_callback(ErrorCallback callback) {
     callback_ = move(callback);
 }
@@ -53,6 +64,10 @@ void BackoffCommitter::commit(const TopicPartitionList& topic_partitions) {
     perform([&] { 
         return do_commit(topic_partitions);
     });
+}
+
+Consumer& BackoffCommitter::get_consumer() {
+    return consumer_;
 }
 
 } // cppkafka

--- a/src/utils/backoff_committer.cpp
+++ b/src/utils/backoff_committer.cpp
@@ -39,17 +39,6 @@ BackoffCommitter::BackoffCommitter(Consumer& consumer)
 
 }
 
-BackoffCommitter::BackoffCommitter(Consumer& consumer,
-                                   TimeUnit initial_backoff,
-                                   TimeUnit backoff_step,
-                                   TimeUnit maximum_backoff,
-                                   BackoffPolicy policy,
-                                   size_t maximum_retries)
-: BackoffPerformer(initial_backoff, backoff_step, maximum_backoff, policy, maximum_retries),
-  consumer_(consumer) {
-  
-}
-
 void BackoffCommitter::set_error_callback(ErrorCallback callback) {
     callback_ = move(callback);
 }

--- a/src/utils/backoff_performer.cpp
+++ b/src/utils/backoff_performer.cpp
@@ -48,6 +48,16 @@ BackoffPerformer::BackoffPerformer()
 
 }
 
+BackoffPerformer::BackoffPerformer(TimeUnit initial_backoff,
+                                   TimeUnit backoff_step,
+                                   TimeUnit maximum_backoff,
+                                   BackoffPolicy policy,
+                                   size_t maximum_retries)
+: initial_backoff_(initial_backoff),
+  backoff_step_(backoff_step), maximum_backoff_(maximum_backoff),
+  policy_(policy), maximum_retries_(maximum_retries) {
+}
+
 void BackoffPerformer::set_backoff_policy(BackoffPolicy policy) {
     policy_ = policy;
 }

--- a/src/utils/backoff_performer.cpp
+++ b/src/utils/backoff_performer.cpp
@@ -48,16 +48,6 @@ BackoffPerformer::BackoffPerformer()
 
 }
 
-BackoffPerformer::BackoffPerformer(TimeUnit initial_backoff,
-                                   TimeUnit backoff_step,
-                                   TimeUnit maximum_backoff,
-                                   BackoffPolicy policy,
-                                   size_t maximum_retries)
-: initial_backoff_(initial_backoff),
-  backoff_step_(backoff_step), maximum_backoff_(maximum_backoff),
-  policy_(policy), maximum_retries_(maximum_retries) {
-}
-
 void BackoffPerformer::set_backoff_policy(BackoffPolicy policy) {
     policy_ = policy;
 }


### PR DESCRIPTION
Both `BufferedProducer` and `RoundRobinPollStrategy` allow access to the internal references so this class should too. It's also nice not having to hold on to the original Consumer reference if we ever need to modify something after the BackoffCommitter is constructed.

Also provided value constructor for the BackoffPerformer class.