### PR TITLE
Producer retry

### DIFF
--- a/include/cppkafka/configuration.h
+++ b/include/cppkafka/configuration.h
@@ -145,7 +145,7 @@ public:
     Configuration& set_default_topic_configuration(TopicConfiguration config);
 
     /**
-     * Returns true iff the given property name has been set
+     * Returns true if the given property name has been set
      */
     bool has_property(const std::string& name) const;
 

--- a/include/cppkafka/cppkafka.h
+++ b/include/cppkafka/cppkafka.h
@@ -44,6 +44,7 @@
 #include <cppkafka/macros.h>
 #include <cppkafka/message.h>
 #include <cppkafka/message_builder.h>
+#include <cppkafka/message_internal.h>
 #include <cppkafka/metadata.h>
 #include <cppkafka/producer.h>
 #include <cppkafka/queue.h>

--- a/include/cppkafka/message.h
+++ b/include/cppkafka/message.h
@@ -180,7 +180,7 @@ private:
 
     Message(rd_kafka_message_t* handle, NonOwningTag);
     Message(HandlePtr handle);
-    void load_internal(void* user_data, InternalPtr internal);
+    Message& load_internal();
 
     HandlePtr handle_;
     Buffer payload_;

--- a/include/cppkafka/message_builder.h
+++ b/include/cppkafka/message_builder.h
@@ -348,6 +348,15 @@ public:
     void construct_buffer(Buffer& lhs, const T& rhs) {
         lhs = Buffer(rhs);
     }
+    
+    MessageBuilder clone() const {
+        return std::move(MessageBuilder(topic()).
+                             key(Buffer(key().get_data(), key().get_size())).
+                             payload(Buffer(payload().get_data(), payload().get_size())).
+                             timestamp(timestamp()).
+                             user_data(user_data()).
+                             internal(internal()));
+    }
 };
 
 /**

--- a/include/cppkafka/message_builder.h
+++ b/include/cppkafka/message_builder.h
@@ -166,6 +166,13 @@ public:
      * Gets the message's user data pointer
      */
     void* user_data() const;
+    
+    /**
+     * Private data accessor (internal use only)
+     */
+    Message::InternalPtr internal() const;
+    Concrete& internal(Message::InternalPtr internal);
+    
 private:
     void construct_buffer(BufferType& lhs, const BufferType& rhs);
     Concrete& get_concrete();
@@ -176,11 +183,13 @@ private:
     BufferType payload_;
     std::chrono::milliseconds timestamp_{0};
     void* user_data_;
+    Message::InternalPtr internal_;
 };
 
 template <typename T, typename C>
 BasicMessageBuilder<T, C>::BasicMessageBuilder(std::string topic)
-: topic_(std::move(topic)) {
+: topic_(std::move(topic)),
+  user_data_(nullptr) {
 }
 
 template <typename T, typename C>
@@ -190,16 +199,16 @@ BasicMessageBuilder<T, C>::BasicMessageBuilder(const Message& message)
   payload_(Buffer(message.get_payload().get_data(), message.get_payload().get_size())),
   timestamp_(message.get_timestamp() ? message.get_timestamp().get().get_timestamp() :
                                        std::chrono::milliseconds(0)),
-  user_data_(message.get_user_data())
-{
-
+  user_data_(message.get_user_data()),
+  internal_(message.internal()) {
 }
 
 template <typename T, typename C>
 template <typename U, typename V>
 BasicMessageBuilder<T, C>::BasicMessageBuilder(const BasicMessageBuilder<U, V>& rhs)
 : topic_(rhs.topic()), partition_(rhs.partition()), timestamp_(rhs.timestamp()),
-  user_data_(rhs.user_data()) {
+  user_data_(rhs.user_data()),
+  internal_(rhs.internal()) {
     get_concrete().construct_buffer(key_, rhs.key());
     get_concrete().construct_buffer(payload_, rhs.payload());
 }
@@ -290,6 +299,17 @@ std::chrono::milliseconds BasicMessageBuilder<T, C>::timestamp() const {
 template <typename T, typename C>
 void* BasicMessageBuilder<T, C>::user_data() const {
     return user_data_;
+}
+
+template <typename T, typename C>
+Message::InternalPtr BasicMessageBuilder<T, C>::internal() const {
+    return internal_;
+}
+
+template <typename T, typename C>
+C& BasicMessageBuilder<T, C>::internal(Message::InternalPtr internal) {
+    internal_ = internal;
+    return get_concrete();
 }
 
 template <typename T, typename C>

--- a/include/cppkafka/message_internal.h
+++ b/include/cppkafka/message_internal.h
@@ -36,7 +36,8 @@ namespace cppkafka {
 
 class Message;
 
-struct Internal {
+class Internal {
+public:
     virtual ~Internal() = default;
 };
 using InternalPtr = std::shared_ptr<Internal>;
@@ -44,15 +45,20 @@ using InternalPtr = std::shared_ptr<Internal>;
 /**
  * \brief Private message data structure
  */
-struct MessageInternal {
+class MessageInternal {
+public:
     MessageInternal(void* user_data, std::shared_ptr<Internal> internal);
     static std::unique_ptr<MessageInternal> load(Message& message);
+    void* get_user_data() const;
+    InternalPtr get_internal() const;
+private:
     void*          user_data_;
     InternalPtr    internal_;
 };
 
 template <typename BuilderType>
-struct MessageInternalGuard {
+class MessageInternalGuard {
+public:
     MessageInternalGuard(BuilderType& builder)
     : builder_(builder),
       user_data_(builder.user_data()) {

--- a/include/cppkafka/producer.h
+++ b/include/cppkafka/producer.h
@@ -31,12 +31,14 @@
 #define CPPKAFKA_PRODUCER_H
 
 #include <memory>
+#include <tuple>
 #include "kafka_handle_base.h"
 #include "configuration.h"
 #include "buffer.h"
 #include "topic.h"
 #include "macros.h"
 #include "message_builder.h"
+#include "message_internal.h"
 
 namespace cppkafka {
 
@@ -78,6 +80,7 @@ class Message;
  */
 class CPPKAFKA_API Producer : public KafkaHandleBase {
 public:
+    friend MessageInternal;
     /**
      * The policy to use for the payload. The default policy is COPY_PAYLOAD
      */
@@ -156,7 +159,11 @@ public:
      */
     void flush(std::chrono::milliseconds timeout);
 private:
+    using LoadResult = std::tuple<void*, std::unique_ptr<MessageInternal>>;
+    LoadResult load_internal(void* user_data, InternalPtr internal);
+    
     PayloadPolicy message_payload_policy_;
+    bool has_internal_data_;
 };
 
 } // cppkafka

--- a/include/cppkafka/producer.h
+++ b/include/cppkafka/producer.h
@@ -31,14 +31,12 @@
 #define CPPKAFKA_PRODUCER_H
 
 #include <memory>
-#include <tuple>
 #include "kafka_handle_base.h"
 #include "configuration.h"
 #include "buffer.h"
 #include "topic.h"
 #include "macros.h"
 #include "message_builder.h"
-#include "message_internal.h"
 
 namespace cppkafka {
 
@@ -80,7 +78,6 @@ class Message;
  */
 class CPPKAFKA_API Producer : public KafkaHandleBase {
 public:
-    friend MessageInternal;
     /**
      * The policy to use for the payload. The default policy is COPY_PAYLOAD
      */
@@ -159,11 +156,7 @@ public:
      */
     void flush(std::chrono::milliseconds timeout);
 private:
-    using LoadResult = std::tuple<void*, std::unique_ptr<MessageInternal>>;
-    LoadResult load_internal(void* user_data, InternalPtr internal);
-    
     PayloadPolicy message_payload_policy_;
-    bool has_internal_data_;
 };
 
 } // cppkafka

--- a/include/cppkafka/utils/buffered_producer.h
+++ b/include/cppkafka/utils/buffered_producer.h
@@ -435,9 +435,9 @@ void BufferedProducer<BufferType>::add_message(Builder builder) {
 template <typename BufferType>
 void BufferedProducer<BufferType>::produce(const MessageBuilder& builder) {
     if (has_internal_data_) {
-        MessageBuilder builder_copy(builder.clone());
-        add_tracker(builder_copy);
-        async_produce(builder_copy, true);
+        MessageBuilder builder_clone(builder.clone());
+        add_tracker(builder_clone);
+        async_produce(builder_clone, true);
     }
     else {
         async_produce(builder, true);
@@ -447,13 +447,13 @@ void BufferedProducer<BufferType>::produce(const MessageBuilder& builder) {
 template <typename BufferType>
 void BufferedProducer<BufferType>::sync_produce(const MessageBuilder& builder) {
     if (has_internal_data_) {
-        MessageBuilder builder_copy(builder.clone());
-        TrackerPtr tracker = add_tracker(builder_copy);
+        MessageBuilder builder_clone(builder.clone());
+        TrackerPtr tracker = add_tracker(builder_clone);
         // produce until we succeed or we reach max retry limit
         std::future<bool> should_retry;
         do {
             should_retry = tracker->get_new_future();
-            produce_message(builder_copy);
+            produce_message(builder_clone);
             wait_for_acks();
         }
         while (should_retry.get());

--- a/include/cppkafka/utils/buffered_producer.h
+++ b/include/cppkafka/utils/buffered_producer.h
@@ -39,10 +39,11 @@
 #include <map>
 #include <mutex>
 #include <atomic>
+#include <future>
 #include <boost/optional.hpp>
 #include "../producer.h"
-#include "../message.h"
 #include "../detail/callback_invoker.h"
+#include "../message_internal.h"
 
 namespace cppkafka {
 
@@ -113,7 +114,7 @@ public:
     BufferedProducer(Configuration config);
 
     /**
-     * \brief Adds a message to the producer's buffer. 
+     * \brief Adds a message to the producer's buffer.
      *
      * The message won't be sent until flush is called.
      *
@@ -122,7 +123,7 @@ public:
     void add_message(const MessageBuilder& builder);
 
     /**
-     * \brief Adds a message to the producer's buffer. 
+     * \brief Adds a message to the producer's buffer.
      *
      * The message won't be sent until flush is called.
      *
@@ -144,6 +145,18 @@ public:
      * \remark This method throws cppkafka::HandleException on failure
      */
     void produce(const MessageBuilder& builder);
+    
+    /**
+     * \brief Produces a message synchronously without buffering it
+     *
+     * In case of failure, the message will be replayed until 'max_number_retries' is reached
+     * or until the user ProduceFailureCallback returns false.
+     *
+     * \param builder The builder that contains the message to be produced
+     *
+     * \remark This method throws cppkafka::HandleException on failure
+     */
+    void sync_produce(const MessageBuilder& builder);
     
     /**
      * \brief Produces a message asynchronously without buffering it
@@ -222,6 +235,13 @@ public:
     size_t get_total_messages_produced() const;
     
     /**
+     * \brief Get the total number of messages dropped since the beginning
+     *
+     * \return The number of messages
+     */
+    size_t get_total_messages_dropped() const;
+    
+    /**
      * \brief Get the total outstanding flush operations in progress
      *
      * Since flush can be called from multiple threads concurrently, this counter indicates
@@ -230,6 +250,20 @@ public:
      * \return The number of outstanding flush operations.
      */
     size_t get_flushes_in_progress() const;
+    
+    /**
+     * \brief Sets the maximum number of retries per message until giving up
+     *
+     * Default is 5
+     */
+    void set_max_number_retries(size_t max_number_retries);
+    
+    /**
+     * \brief Gets the max number of retries
+     *
+     * \return The number of retries
+     */
+    size_t get_max_number_retries() const;
 
     /**
      * Gets the Producer object
@@ -285,9 +319,29 @@ public:
      */
     void set_flush_failure_callback(FlushFailureCallback callback);
     
+    struct TestParameters {
+        bool force_delivery_error_;
+        bool force_produce_error_;
+    };
+protected:
+    //For testing purposes only
+#ifdef KAFKA_TEST_INSTANCE
+    void set_test_parameters(TestParameters *test_params) {
+        test_params_ = test_params;
+    }
+    TestParameters* get_test_parameters() {
+        return test_params_;
+    }
+#else
+    TestParameters* get_test_parameters() {
+        return nullptr;
+    }
+#endif
+    
 private:
     using QueueType = std::deque<Builder>;
     enum class MessagePriority { Low, High };
+    enum class SenderType { Sync, Async };
     
     template <typename T>
     struct CounterGuard{
@@ -295,13 +349,29 @@ private:
         ~CounterGuard() { --counter_; }
         std::atomic<T>& counter_;
     };
+    
+    struct Tracker : public Internal {
+        Tracker(SenderType sender, size_t num_retries)
+            : sender_(sender), num_retries_(num_retries)
+        {}
+        std::future<bool> get_new_future() {
+            should_retry_ = std::promise<bool>(); //reset shared data
+            return should_retry_.get_future(); //issue new future
+        }
+        SenderType sender_;
+        std::promise<bool> should_retry_;
+        size_t num_retries_;
+    };
 
     template <typename BuilderType>
     void do_add_message(BuilderType&& builder, MessagePriority priority, bool do_flush);
+    void do_add_message(const Message& message, MessagePriority priority, bool do_flush);
     template <typename MessageType>
-    void produce_message(const MessageType& message);
+    void produce_message(MessageType&& message);
     Configuration prepare_configuration(Configuration config);
     void on_delivery_report(const Message& message);
+    template <typename MessageType>
+    void async_produce(MessageType&& message, bool throw_on_error);
     
     // Members
     Producer producer_;
@@ -314,6 +384,11 @@ private:
     std::atomic<size_t> pending_acks_{0};
     std::atomic<size_t> flushes_in_progress_{0};
     std::atomic<size_t> total_messages_produced_{0};
+    std::atomic<size_t> total_messages_dropped_{0};
+    int max_number_retries_{5};
+#ifdef KAFKA_TEST_INSTANCE
+    TestParameters* test_params_;
+#endif
 };
 
 template <typename BufferType>
@@ -330,26 +405,52 @@ template <typename BufferType>
 BufferedProducer<BufferType>::BufferedProducer(Configuration config)
 : producer_(prepare_configuration(std::move(config))) {
     producer_.set_payload_policy(get_default_payload_policy<BufferType>());
+#ifdef KAFKA_TEST_INSTANCE
+    test_params_ = nullptr;
+#endif
 }
 
 template <typename BufferType>
 void BufferedProducer<BufferType>::add_message(const MessageBuilder& builder) {
+    // Add message tracker
+    std::shared_ptr<Tracker> tracker = std::make_shared<Tracker>(SenderType::Async, max_number_retries_);
+    const_cast<MessageBuilder&>(builder).internal(tracker);
     do_add_message(builder, MessagePriority::Low, true);
 }
 
 template <typename BufferType>
 void BufferedProducer<BufferType>::add_message(Builder builder) {
+    // Add message tracker
+    std::shared_ptr<Tracker> tracker = std::make_shared<Tracker>(SenderType::Async, max_number_retries_);
+    const_cast<Builder&>(builder).internal(tracker);
     do_add_message(move(builder), MessagePriority::Low, true);
 }
 
 template <typename BufferType>
 void BufferedProducer<BufferType>::produce(const MessageBuilder& builder) {
-    produce_message(builder);
+    // Add message tracker
+    std::shared_ptr<Tracker> tracker = std::make_shared<Tracker>(SenderType::Async, max_number_retries_);
+    const_cast<MessageBuilder&>(builder).internal(tracker);
+    async_produce(builder, true);
+}
+
+template <typename BufferType>
+void BufferedProducer<BufferType>::sync_produce(const MessageBuilder& builder) {
+    // Add message tracker
+    std::shared_ptr<Tracker> tracker = std::make_shared<Tracker>(SenderType::Async, max_number_retries_);
+    const_cast<MessageBuilder&>(builder).internal(tracker);
+    std::future<bool> should_retry;
+    do {
+        should_retry = tracker->get_new_future();
+        produce_message(builder);
+        wait_for_acks();
+    }
+    while (should_retry.get());
 }
 
 template <typename BufferType>
 void BufferedProducer<BufferType>::produce(const Message& message) {
-    produce_message(message);
+    async_produce(message, true);
 }
 
 template <typename BufferType>
@@ -361,16 +462,7 @@ void BufferedProducer<BufferType>::flush() {
         std::swap(messages_, flush_queue);
     }
     while (!flush_queue.empty()) {
-        try {
-            produce_message(flush_queue.front());
-        }
-        catch (const HandleException& ex) {
-            // If we have a flush failure callback and it returns true, we retry producing this message later
-            CallbackInvoker<FlushFailureCallback> callback("flush failure", flush_failure_callback_, &producer_);
-            if (callback && callback(flush_queue.front(), ex.get_error())) {
-                do_add_message(std::move(flush_queue.front()), MessagePriority::Low, false);
-            }
-        }
+        async_produce(std::move(flush_queue.front()), false);
         flush_queue.pop_front();
     }
     wait_for_acks();
@@ -427,15 +519,22 @@ void BufferedProducer<BufferType>::do_add_message(BuilderType&& builder,
     {
         std::lock_guard<std::mutex> lock(mutex_);
         if (priority == MessagePriority::High) {
-            messages_.emplace_front(std::move(builder));
+            messages_.emplace_front(std::forward<BuilderType>(builder));
         }
         else {
-            messages_.emplace_back(std::move(builder));
+            messages_.emplace_back(std::forward<BuilderType>(builder));
         }
     }
     if (do_flush && (max_buffer_size_ >= 0) && (max_buffer_size_ <= (ssize_t)messages_.size())) {
         flush();
     }
+}
+
+template <typename BufferType>
+void BufferedProducer<BufferType>::do_add_message(const Message& message,
+                                                  MessagePriority priority,
+                                                  bool do_flush) {
+    do_add_messsage(MessageBuilder(message), priority, do_flush);
 }
 
 template <typename BufferType>
@@ -459,8 +558,23 @@ size_t BufferedProducer<BufferType>::get_total_messages_produced() const {
 }
 
 template <typename BufferType>
+size_t BufferedProducer<BufferType>::get_total_messages_dropped() const {
+    return total_messages_dropped_;
+}
+
+template <typename BufferType>
 size_t BufferedProducer<BufferType>::get_flushes_in_progress() const {
     return flushes_in_progress_;
+}
+
+template <typename BufferType>
+void BufferedProducer<BufferType>::set_max_number_retries(size_t max_number_retries) {
+    max_number_retries_ = max_number_retries;
+}
+
+template <typename BufferType>
+size_t BufferedProducer<BufferType>::get_max_number_retries() const {
+    return max_number_retries_;
 }
 
 template <typename BufferType>
@@ -486,10 +600,10 @@ void BufferedProducer<BufferType>::set_flush_failure_callback(FlushFailureCallba
 
 template <typename BufferType>
 template <typename MessageType>
-void BufferedProducer<BufferType>::produce_message(const MessageType& message) {
+void BufferedProducer<BufferType>::produce_message(MessageType&& message) {
     while (true) {
         try {
-            producer_.produce(message);
+            producer_.produce(std::forward<MessageType>(message));
             // Sent successfully
             ++pending_acks_;
             break;
@@ -507,6 +621,34 @@ void BufferedProducer<BufferType>::produce_message(const MessageType& message) {
 }
 
 template <typename BufferType>
+template <typename MessageType>
+void BufferedProducer<BufferType>::async_produce(MessageType&& message, bool throw_on_error) {
+    try {
+        TestParameters* test_params = get_test_parameters();
+        if (test_params && test_params->force_produce_error_) {
+            throw HandleException(Error(RD_KAFKA_RESP_ERR_UNKNOWN));
+        }
+        produce_message(std::forward<MessageType>(message));
+    }
+    catch (const HandleException& ex) {
+        // If we have a flush failure callback and it returns true, we retry producing this message later
+        CallbackInvoker<FlushFailureCallback> callback("flush failure", flush_failure_callback_, &producer_);
+        if (!callback || callback(std::forward<MessageType>(message), ex.get_error())) {
+            std::shared_ptr<Tracker> tracker = std::static_pointer_cast<Tracker>(message.internal());
+            if (tracker->num_retries_ > 0) {
+                --tracker->num_retries_;
+                do_add_message(std::forward<MessageType>(message), MessagePriority::High, false);
+                return;
+            }
+        }
+        ++total_messages_dropped_;
+        if (throw_on_error) {
+            throw;
+        }
+    }
+}
+
+template <typename BufferType>
 Configuration BufferedProducer<BufferType>::prepare_configuration(Configuration config) {
     using std::placeholders::_2;
     auto callback = std::bind(&BufferedProducer<BufferType>::on_delivery_report, this, _2);
@@ -516,13 +658,30 @@ Configuration BufferedProducer<BufferType>::prepare_configuration(Configuration 
 
 template <typename BufferType>
 void BufferedProducer<BufferType>::on_delivery_report(const Message& message) {
-    if (message.get_error()) {
+    //Get tracker data
+    TestParameters* test_params = get_test_parameters();
+    std::shared_ptr<Tracker> tracker = std::static_pointer_cast<Tracker>(message.internal());
+    bool should_retry = false;
+    if (message.get_error() || (test_params && test_params->force_delivery_error_)) {
         // We should produce this message again if we don't have a produce failure callback
         // or we have one but it returns true
         CallbackInvoker<ProduceFailureCallback> callback("produce failure", produce_failure_callback_, &producer_);
         if (!callback || callback(message)) {
-            // Re-enqueue for later retransmission with higher priority (i.e. front of the queue)
-            do_add_message(Builder(message), MessagePriority::High, false);
+            // Check if we have reached the maximum retry limit
+            if (tracker->num_retries_ > 0) {
+                --tracker->num_retries_;
+                if (tracker->sender_ == SenderType::Async) {
+                    // Re-enqueue for later retransmission with higher priority (i.e. front of the queue)
+                    do_add_message(Builder(message), MessagePriority::High, false);
+                }
+                should_retry = true;
+            }
+            else {
+                ++total_messages_dropped_;
+            }
+        }
+        else {
+            ++total_messages_dropped_;
         }
     }
     else {
@@ -531,6 +690,8 @@ void BufferedProducer<BufferType>::on_delivery_report(const Message& message) {
         // Increment the total successful transmissions
         ++total_messages_produced_;
     }
+    // Signal producers
+    tracker->should_retry_.set_value(should_retry);
     // Decrement the expected acks
     --pending_acks_;
     assert(pending_acks_ != (size_t)-1); // Prevent underflow

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCES
     buffer.cpp
     queue.cpp
     message.cpp
+    message_internal.cpp
     topic_partition.cpp
     topic_partition_list.cpp
     metadata.cpp

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -31,7 +31,7 @@
 #include <vector>
 #include <librdkafka/rdkafka.h>
 #include "exceptions.h"
-#include "message.h"
+#include "message_internal.h"
 #include "producer.h"
 #include "consumer.h"
 
@@ -40,7 +40,7 @@ using std::map;
 using std::move;
 using std::vector;
 using std::initializer_list;
-
+using std::unique_ptr;
 using boost::optional;
 
 using std::chrono::milliseconds;
@@ -52,6 +52,7 @@ namespace cppkafka {
 void delivery_report_callback_proxy(rd_kafka_t*, const rd_kafka_message_t* msg, void *opaque) {
     Producer* handle = static_cast<Producer*>(opaque);
     Message message = Message::make_non_owning((rd_kafka_message_t*)msg);
+    unique_ptr<MessageInternal> internal_data(MessageInternal::load(message));
     CallbackInvoker<Configuration::DeliveryReportCallback>
         ("delivery report", handle->get_configuration().get_delivery_report_callback(), handle)
         (*handle, message);

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -52,7 +52,7 @@ namespace cppkafka {
 void delivery_report_callback_proxy(rd_kafka_t*, const rd_kafka_message_t* msg, void *opaque) {
     Producer* handle = static_cast<Producer*>(opaque);
     Message message = Message::make_non_owning((rd_kafka_message_t*)msg);
-    unique_ptr<MessageInternal> internal_data(MessageInternal::load(message));
+    unique_ptr<MessageInternal> internal_data(MessageInternal::load(*handle, message));
     CallbackInvoker<Configuration::DeliveryReportCallback>
         ("delivery report", handle->get_configuration().get_delivery_report_callback(), handle)
         (*handle, message);

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -31,7 +31,7 @@
 #include <vector>
 #include <librdkafka/rdkafka.h>
 #include "exceptions.h"
-#include "message_internal.h"
+#include "message.h"
 #include "producer.h"
 #include "consumer.h"
 
@@ -40,10 +40,8 @@ using std::map;
 using std::move;
 using std::vector;
 using std::initializer_list;
-using std::unique_ptr;
-using boost::optional;
-
 using std::chrono::milliseconds;
+using boost::optional;
 
 namespace cppkafka {
 
@@ -52,7 +50,6 @@ namespace cppkafka {
 void delivery_report_callback_proxy(rd_kafka_t*, const rd_kafka_message_t* msg, void *opaque) {
     Producer* handle = static_cast<Producer*>(opaque);
     Message message = Message::make_non_owning((rd_kafka_message_t*)msg);
-    unique_ptr<MessageInternal> internal_data(MessageInternal::load(*handle, message));
     CallbackInvoker<Configuration::DeliveryReportCallback>
         ("delivery report", handle->get_configuration().get_delivery_report_callback(), handle)
         (*handle, message);

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -68,8 +68,8 @@ Message::Message(HandlePtr handle)
 Message& Message::load_internal() {
     if (user_data_) {
         MessageInternal* mi = static_cast<MessageInternal*>(user_data_);
-        user_data_ = mi->user_data_;
-        internal_ = mi->internal_;
+        user_data_ = mi->get_user_data();
+        internal_ = mi->get_internal();
     }
     return *this;
 }

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -28,6 +28,7 @@
  */
 
 #include "message.h"
+#include "message_internal.h"
 
 using std::chrono::milliseconds;
 
@@ -64,9 +65,13 @@ Message::Message(HandlePtr handle)
   user_data_(handle_ ? handle_->_private : nullptr) {
 }
 
-void Message::load_internal(void* user_data, InternalPtr internal) {
-    user_data_ = user_data;
-    internal_ = internal;
+Message& Message::load_internal() {
+    if (user_data_) {
+        MessageInternal* mi = static_cast<MessageInternal*>(user_data_);
+        user_data_ = mi->user_data_;
+        internal_ = mi->internal_;
+    }
+    return *this;
 }
 
 // MessageTimestamp

--- a/src/message_internal.cpp
+++ b/src/message_internal.cpp
@@ -45,4 +45,12 @@ std::unique_ptr<MessageInternal> MessageInternal::load(Message& message) {
                                             static_cast<MessageInternal*>(message.get_handle()->_private) : nullptr);
 }
 
+void* MessageInternal::get_user_data() const {
+    return user_data_;
+}
+
+InternalPtr MessageInternal::get_internal() const {
+    return internal_;
+}
+
 }

--- a/src/message_internal.cpp
+++ b/src/message_internal.cpp
@@ -27,23 +27,22 @@
  *
  */
 #include "message_internal.h"
-#include "producer.h"
+#include "message.h"
+#include "message_builder.h"
 
 namespace cppkafka {
 
-MessageInternal::MessageInternal(void* user_data, std::shared_ptr<Internal> internal)
+// MessageInternal
+
+MessageInternal::MessageInternal(void* user_data,
+                                 std::shared_ptr<Internal> internal)
 : user_data_(user_data),
   internal_(internal) {
 }
 
-std::unique_ptr<MessageInternal> MessageInternal::load(const Producer& producer, Message& message) {
-    if (producer.has_internal_data_ && message.get_user_data()) {
-        // Unpack internal data
-        std::unique_ptr<MessageInternal> internal_data(static_cast<MessageInternal*>(message.get_user_data()));
-        message.load_internal(internal_data->user_data_, internal_data->internal_);
-        return internal_data;
-    }
-    return nullptr;
+std::unique_ptr<MessageInternal> MessageInternal::load(Message& message) {
+    return std::unique_ptr<MessageInternal>(message.load_internal().get_handle() ?
+                                            static_cast<MessageInternal*>(message.get_handle()->_private) : nullptr);
 }
 
 }

--- a/tests/producer_test.cpp
+++ b/tests/producer_test.cpp
@@ -74,6 +74,7 @@ void flusher_run(BufferedProducer<string>& producer,
         if (producer.get_buffer_size() >= (size_t)num_flush) {
             producer.flush();
         }
+        this_thread::sleep_for(milliseconds(10));
     }
     producer.flush();
 }
@@ -85,6 +86,36 @@ void clear_run(BufferedProducer<string>& producer,
     clear.wait(lock);
     producer.clear();
 }
+
+vector<int> dr_data = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+void dr_callback(const Message& message) {
+    static int i = 0;
+    if (!message || message.is_eof()) return;
+    CHECK(message.get_user_data() == &dr_data[i]);
+    CHECK(*static_cast<int*>(message.get_user_data()) == dr_data[i]);
+    ++i;
+}
+
+bool dr_failure_callback(const Message& message) {
+    if (!message || message.is_eof()) return true;
+    CHECK(message.get_user_data() == &dr_data[0]);
+    CHECK(*static_cast<int*>(message.get_user_data()) == dr_data[0]);
+    return true; //always retry
+}
+
+template <typename B>
+class ErrorProducer : public BufferedProducer<B>
+{
+public:
+    ErrorProducer(Configuration config,
+                  typename BufferedProducer<B>::TestParameters params) :
+        BufferedProducer<B>(config),
+        params_(params) {
+        this->set_test_parameters(&params_);
+    }
+private:
+    typename BufferedProducer<B>::TestParameters params_;
+};
 
 TEST_CASE("simple production", "[producer]") {
     int partition = 0;
@@ -269,6 +300,86 @@ TEST_CASE("multiple messages", "[producer]") {
         CHECK(message.get_partition() >= 0);
         CHECK(message.get_partition() < KAFKA_NUM_PARTITIONS);
     }
+}
+
+TEST_CASE("multiple sync messages", "[producer][buffered_producer][sync]") {
+    size_t message_count = 10;
+    set<string> payloads;
+
+    // Create a consumer and subscribe to this topic
+    Consumer consumer(make_consumer_config());
+    consumer.subscribe({ KAFKA_TOPICS[0] });
+    ConsumerRunner runner(consumer, message_count, KAFKA_NUM_PARTITIONS);
+
+    // Now create a producer and produce a message
+    BufferedProducer<string> producer(make_producer_config());
+    producer.set_produce_success_callback(dr_callback);
+    const string payload_base = "Hello world ";
+    for (size_t i = 0; i < message_count; ++i) {
+        const string payload = payload_base + to_string(i);
+        payloads.insert(payload);
+        producer.sync_produce(MessageBuilder(KAFKA_TOPICS[0]).payload(payload).user_data(&dr_data[i]));
+    }
+    runner.try_join();
+
+    const auto& messages = runner.get_messages();
+    REQUIRE(messages.size() == message_count);
+    for (size_t i = 0; i < messages.size(); ++i) {
+        const auto& message = messages[i];
+        CHECK(message.get_topic() == KAFKA_TOPICS[0]);
+        CHECK(payloads.erase(message.get_payload()) == 1);
+        CHECK(!!message.get_error() == false);
+        CHECK(!!message.get_key() == false);
+        CHECK(message.get_partition() >= 0);
+        CHECK(message.get_partition() < KAFKA_NUM_PARTITIONS);
+    }
+}
+
+TEST_CASE("replay sync messages with errors", "[producer][buffered_producer][sync]") {
+    size_t num_retries = 4;
+
+    // Create a consumer and subscribe to this topic
+    Consumer consumer(make_consumer_config());
+    consumer.subscribe({ KAFKA_TOPICS[0] });
+    ConsumerRunner runner(consumer, num_retries+1, KAFKA_NUM_PARTITIONS);
+
+    // Now create a producer and produce a message
+    ErrorProducer<string> producer(make_producer_config(), BufferedProducer<string>::TestParameters{true, false});
+    producer.set_produce_failure_callback(dr_failure_callback);
+    producer.set_max_number_retries(num_retries);
+    string payload = "Hello world";
+    producer.sync_produce(MessageBuilder(KAFKA_TOPICS[0]).payload(payload).user_data(&dr_data[0]));
+    runner.try_join();
+
+    const auto& messages = runner.get_messages();
+    REQUIRE(messages.size() == num_retries+1);
+    for (size_t i = 0; i < messages.size(); ++i) {
+        const auto& message = messages[i];
+        CHECK(message.get_topic() == KAFKA_TOPICS[0]);
+        CHECK(message.get_payload() == payload);
+        CHECK(!!message.get_error() == false);
+        CHECK(!!message.get_key() == false);
+        CHECK(message.get_partition() >= 0);
+        CHECK(message.get_partition() < KAFKA_NUM_PARTITIONS);
+    }
+}
+
+TEST_CASE("replay async messages with errors", "[producer][buffered_producer][async]") {
+    size_t num_retries = 4;
+    int exit_flag = 0;
+
+    // Now create a producer and produce a message
+    ErrorProducer<string> producer(make_producer_config(),
+                                   BufferedProducer<string>::TestParameters{false, true});
+    producer.set_max_number_retries(num_retries);
+    thread flusher_thread(flusher_run, ref(producer), ref(exit_flag), 0);
+    string payload = "Hello world";
+    producer.produce(MessageBuilder(KAFKA_TOPICS[0]).payload(payload));
+    this_thread::sleep_for(milliseconds(2000));
+    exit_flag = 1;
+    flusher_thread.join();
+    REQUIRE(producer.get_total_messages_produced() == 0);
+    CHECK(producer.get_total_messages_dropped() == 1);
 }
 
 TEST_CASE("buffered producer", "[producer][buffered_producer]") {


### PR DESCRIPTION
### Description
This PR can be decomposed logically into two segments:
* Retry logic in the `BufferedProducer`
* A generic mechanism to pass internal/private/hidden cppkafka data inside the message user_data.

### Scope of changes 
* Allow the tracking of produced messages so that retry logic can be enforced inside the `BufferedProducer` class. Since the mechanism is generic, other classes may provide their own _private_ data and use it internally. 
* Locality of changes is limited to `BufferedProducer`, `Producer`, `MessageBuilder` and `Message` class. Most changes are the actual retry logic inside `BufferedProducer`. The other classes have _minimal_ changes.
* Dependency injection of test parameters was added to the `BufferedProducer` class to allow testing of various scenarios. Currently this was not possible.
* Added `BufferedProducer::sync_produce` and provided the user with a way to set the max number of message retries. In any application, retrying is an important feature, therefore this PR addresses that at a generic level, not having to be implemented by users, every time.
* Added retry logic for `BufferedProducer::produce` which is asynchronous, by refactoring common logic into `async_produce` function. The original `Buffered::produce` functions still throw on error after all the retries have been exhausted, as such the behavior is unchanged.
* Added counter for number of messages dropped in `BufferedProducer` class.

### Private data ownership and tracking
* The code interposes a small structure named `MessageInternal` between the `user_data` pointer and the opaque pointer provided by rdkafka when producing messages. This structure has some additional `Internal` metadata (different ones can be provided for different purposes as stated above -- in this case we use a `Tracker` object) and is entirely managed by `unique_ptr` ownership.
* On the produce side, the only two overloaded entry points [`produce(MessageBuilder)` and `produce(Message)`] create each time a *new* `unique_ptr<MessageInternal>` structure before passing it to rdkafka. Should the produce method throw, the objects are deleted, otherwise the pointers are released. 
* On the `dr_callback side`, this data is loaded inside a `unique_ptr<MessageInternal>` at the beginning of the `dr_callback_proxy` and is deleted on exit. 
* Based on the above design, there is no point where the memory leaks.
* The `Tracker` objects are managed via `shared_ptr` and their lifetime depends on all owners (i.e. `MessageBuilder` and `Message` instances).
* Care has been taken to hide all manipulation of the `MessageInternal` object. As such, it is impossible for any user to cause an error or to misuse the API. 

### User data
* All the original methods of setting/getting user data which are part of the `MessageBuilder`, as well as the user data getter in `Message` class behave exactly as before. Users can pass and retrieve their own pointers transparently.

### Consumer
* On the consumer side, the `Message` object remains unchanged. 

### Testing
* Test cases have been added to test the sync and async producer as well as the retry mechanism in case of failure. Also various produce tests including re-producing a `MessageBuilder` and a `Message` object multiple times. 
* Test cases have been added to pass and retrieve application specific opaque user data. 

