### PR TITLE
Fix crash in Buffer with null pointer and non-zero length

### DIFF
--- a/include/cppkafka/buffer.h
+++ b/include/cppkafka/buffer.h
@@ -35,6 +35,7 @@
 #include <iosfwd>
 #include <algorithm>
 #include "macros.h"
+#include "exceptions.h"
 
 namespace cppkafka {
 
@@ -75,6 +76,9 @@ public:
     Buffer(const T* data, size_t size) 
     : data_(reinterpret_cast<const DataType*>(data)), size_(size) {
         static_assert(sizeof(T) == sizeof(DataType), "sizeof(T) != sizeof(DataType)");
+        if ((data_ == nullptr) && (size_ > 0)) {
+            throw Exception("Invalid buffer configuration");
+        }
     }
 
     /**

--- a/src/buffer.cpp
+++ b/src/buffer.cpp
@@ -67,11 +67,11 @@ Buffer::const_iterator Buffer::end() const {
 }
 
 Buffer::operator bool() const {
-    return (data_ != nullptr) && (size_ != 0);
+    return size_ != 0;
 }
 
 Buffer::operator string() const {
-    return (bool)(*this) ? string(data_, data_ + size_) : string();
+    return string(data_, data_ + size_);
 }
 
 ostream& operator<<(ostream& output, const Buffer& rhs) {

--- a/src/buffer.cpp
+++ b/src/buffer.cpp
@@ -67,11 +67,11 @@ Buffer::const_iterator Buffer::end() const {
 }
 
 Buffer::operator bool() const {
-    return size_ != 0;
+    return (data_ != nullptr) && (size_ != 0);
 }
 
 Buffer::operator string() const {
-    return string(data_, data_ + size_);
+    return (bool)(*this) ? string(data_, data_ + size_) : string();
 }
 
 ostream& operator<<(ostream& output, const Buffer& rhs) {

--- a/tests/buffer_test.cpp
+++ b/tests/buffer_test.cpp
@@ -14,16 +14,22 @@ TEST_CASE("conversions", "[buffer]") {
     const string data = "Hello world!";
     const Buffer buffer(data);
     const Buffer empty_buffer;
+    const Buffer null_data((const char*)nullptr, 5);
+    const Buffer null_size(data.c_str(), 0);
 
 
     SECTION("bool conversion") {
         CHECK(!!buffer == true);
         CHECK(!!empty_buffer == false);
+        CHECK(!!null_data == false);
+        CHECK(!!null_size == false);
     }
 
     SECTION("string conversion") {
         CHECK(static_cast<string>(buffer) == data);
         CHECK(static_cast<string>(empty_buffer).empty());
+        CHECK(static_cast<string>(null_data).empty());
+        CHECK(static_cast<string>(null_size).empty());
     }
 
     SECTION("vector conversion") {

--- a/tests/buffer_test.cpp
+++ b/tests/buffer_test.cpp
@@ -14,22 +14,19 @@ TEST_CASE("conversions", "[buffer]") {
     const string data = "Hello world!";
     const Buffer buffer(data);
     const Buffer empty_buffer;
-    const Buffer null_data((const char*)nullptr, 5);
-    const Buffer null_size(data.c_str(), 0);
 
+    SECTION("construction") {
+        CHECK_THROWS_AS(Buffer((const char*)nullptr, 5), Exception);
+    }
 
     SECTION("bool conversion") {
         CHECK(!!buffer == true);
         CHECK(!!empty_buffer == false);
-        CHECK(!!null_data == false);
-        CHECK(!!null_size == false);
     }
 
     SECTION("string conversion") {
         CHECK(static_cast<string>(buffer) == data);
         CHECK(static_cast<string>(empty_buffer).empty());
-        CHECK(static_cast<string>(null_data).empty());
-        CHECK(static_cast<string>(null_size).empty());
     }
 
     SECTION("vector conversion") {


### PR DESCRIPTION
When a `Buffer` is built with null ptr and size > 0, the `operator bool` return true but any conversion to `string` crashes. 