### PR TITLE
Fix for ref count on queue handles

### DIFF
--- a/include/cppkafka/consumer.h
+++ b/include/cppkafka/consumer.h
@@ -403,7 +403,7 @@ public:
      * \return A Queue object
      *
      * \remark Note that this call will disable forwarding to the consumer_queue.
-     *         To restore forwarding (if desired) call Queue::forward_to_queue(consumer_queue)
+     *         To restore forwarding if desired, call Queue::forward_to_queue(consumer_queue)
      */
     Queue get_main_queue() const;
     
@@ -424,7 +424,7 @@ public:
      * \return A Queue object
      *
      * \remark Note that this call will disable forwarding to the consumer_queue.
-     *         To restore forwarding (if desired) call Queue::forward_to_queue(consumer_queue)
+     *         To restore forwarding if desired, call Queue::forward_to_queue(consumer_queue)
      */
     Queue get_partition_queue(const TopicPartition& partition) const;
 private:

--- a/src/consumer.cpp
+++ b/src/consumer.cpp
@@ -262,19 +262,19 @@ MessageList Consumer::poll_batch(size_t max_batch_size, milliseconds timeout) {
 }
 
 Queue Consumer::get_main_queue() const {
-    Queue queue(Queue::make_non_owning(rd_kafka_queue_get_main(get_handle())));
+    Queue queue(rd_kafka_queue_get_main(get_handle()));
     queue.disable_queue_forwarding();
     return queue;
 }
 
 Queue Consumer::get_consumer_queue() const {
-    return Queue::make_non_owning(rd_kafka_queue_get_consumer(get_handle()));
+    return rd_kafka_queue_get_consumer(get_handle());
 }
 
 Queue Consumer::get_partition_queue(const TopicPartition& partition) const {
-    Queue queue(Queue::make_non_owning(rd_kafka_queue_get_partition(get_handle(),
-                                                                    partition.get_topic().c_str(),
-                                                                    partition.get_partition())));
+    Queue queue(rd_kafka_queue_get_partition(get_handle(),
+                                             partition.get_topic().c_str(),
+                                             partition.get_partition()));
     queue.disable_queue_forwarding();
     return queue;
 }

--- a/src/consumer.cpp
+++ b/src/consumer.cpp
@@ -262,19 +262,33 @@ MessageList Consumer::poll_batch(size_t max_batch_size, milliseconds timeout) {
 }
 
 Queue Consumer::get_main_queue() const {
+#if RD_KAFKA_VERSION <= 0x000b0500
+    Queue queue(Queue::make_non_owning(rd_kafka_queue_get_main(get_handle())));
+#else
     Queue queue(rd_kafka_queue_get_main(get_handle()));
+#endif
     queue.disable_queue_forwarding();
     return queue;
 }
 
 Queue Consumer::get_consumer_queue() const {
+#if RD_KAFKA_VERSION <= 0x000b0500
+    return Queue::make_non_owning(rd_kafka_queue_get_consumer(get_handle()));
+#else
     return rd_kafka_queue_get_consumer(get_handle());
+#endif
 }
 
 Queue Consumer::get_partition_queue(const TopicPartition& partition) const {
+#if RD_KAFKA_VERSION <= 0x000b0500
+    Queue queue(Queue::make_non_owning(rd_kafka_queue_get_partition(get_handle(),
+                                                                    partition.get_topic().c_str(),
+                                                                    partition.get_partition())));
+#else
     Queue queue(rd_kafka_queue_get_partition(get_handle(),
                                              partition.get_topic().c_str(),
                                              partition.get_partition()));
+#endif
     queue.disable_queue_forwarding();
     return queue;
 }


### PR DESCRIPTION
Seems like the previous issue on queue ref count was finally [fixed](https://github.com/edenhill/librdkafka/issues/1792). I tested and everything seems fine now. Before, unless the handles were non-owning tests would fail.