### PR TITLE
Specific linking option for rdkafka library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(cppkafka)
 set(CPPKAFKA_VERSION_MAJOR 0)
 set(CPPKAFKA_VERSION_MINOR 1)
 set(CPPKAFKA_VERSION "${CPPKAFKA_VERSION_MAJOR}.${CPPKAFKA_VERSION_MINOR}")
+set(RDKAFKA_MIN_VERSION 0x00090400)
 
 if(MSVC)
     # Don't always use Wall, since VC's /Wall is ridiculously verbose.
@@ -30,6 +31,7 @@ option(CPPKAFKA_DISABLE_TESTS "Disable build of cppkafka tests." OFF)
 option(CPPKAFKA_DISABLE_EXAMPLES "Disable build of cppkafka examples." OFF)
 option(CPPKAFKA_BOOST_STATIC_LIBS "Link with Boost static libraries." ON)
 option(CPPKAFKA_BOOST_USE_MULTITHREADED "Use Boost multithreaded libraries." ON)
+option(CPPKAFKA_RDKAFKA_STATIC_LIB "Link with Rdkafka static library." OFF)
 
 # Disable output from find_package macro
 if (NOT CPPKAFKA_CMAKE_VERBOSE)

--- a/README.md
+++ b/README.md
@@ -77,13 +77,16 @@ The following cmake options can be specified:
 * `CPPKAFKA_DISABLE_EXAMPLES` : Disable build of cppkafka examples. Default is `OFF`.
 * `CPPKAFKA_BOOST_STATIC_LIBS` : Link with Boost static libraries. Default is `ON`.
 * `CPPKAFKA_BOOST_USE_MULTITHREADED` : Use Boost multi-threaded libraries. Default is `ON`.
+* `CPPKAFKA_RDKAFKA_STATIC_LIB` : Link to Rdkafka static library. Default is `OFF`.
 
 Example:
 ```Shell
 cmake -DRDKAFKA_ROOT_DIR=/some/other/dir -DCPPKAFKA_BUILD_SHARED=OFF ...
 ```
 
-Note that the `RDKAFKA_ROOT_DIR` must contain the following structure:
+The `RDKAFKA_ROOT_DIR` must contain the following structure. If the system
+architecture is 64-bit and both `lib` and `lib64` folders are available, the `lib64`
+folder location will be selected by cmake.
 
 ```Shell
 ${RDKAFKA_ROOT_DIR}/
@@ -91,6 +94,8 @@ ${RDKAFKA_ROOT_DIR}/
                    + include/librdkafka/rdkafka.h
                    |
                    + lib/librdkafka.a
+                   |
+                   + lib64/librdkafka.a (optional)
 ```
 
 # Using


### PR DESCRIPTION
Gives an option at build time to statically or dynamically link the rdkafka library. The issue is that if both .a and .so files are present in the same directory (or .lib and .dll for windows), cmake seems to prefer the shared library by default. The only way to control this is to force `find_path` to look for more specific names first and then the more generic names (without a suffix) afterward.
If `.a .so .lib and .dll` files are not there, the default cmake search pattern will be used.