### PR TITLE
Fix #97: `struct` switched to `class`.

### DIFF
--- a/include/cppkafka/message.h
+++ b/include/cppkafka/message.h
@@ -43,7 +43,7 @@
 namespace cppkafka {
 
 class MessageTimestamp;
-struct Internal;
+class Internal;
 
 /**
  * \brief Thin wrapper over a rdkafka message handle


### PR DESCRIPTION
To avoid name mangling difference in MSVC.

I'm not sure this class should be marked as API.