### PR TITLE
Fix #104: memory leak in poll_batch

### DIFF
--- a/src/consumer.cpp
+++ b/src/consumer.cpp
@@ -261,7 +261,7 @@ MessageList Consumer::poll_batch(size_t max_batch_size) {
 
 MessageList Consumer::poll_batch(size_t max_batch_size, milliseconds timeout) {
     vector<rd_kafka_message_t*> raw_messages(max_batch_size);
-    rd_kafka_queue_t* queue = rd_kafka_queue_get_consumer(get_handle());
+    Queue queue(rd_kafka_queue_get_consumer(get_handle()));
     ssize_t result = rd_kafka_consume_batch_queue(queue, timeout.count(), raw_messages.data(),
                                                   raw_messages.size());
     if (result == -1) {


### PR DESCRIPTION
poll_batch currently leaks memory while initialising the queue
returned by rd_kafka_queue_get_consumer. The fix as suggested
by @mfontanini as done here is to initialise the queue with a
Queue so it's cleaned up when going out of scope.