### PR TITLE
Fix #104: optimize performance for poll_batch queue

### DIFF
--- a/include/cppkafka/consumer.h
+++ b/include/cppkafka/consumer.h
@@ -438,6 +438,7 @@ private:
     AssignmentCallback assignment_callback_;
     RevocationCallback revocation_callback_;
     RebalanceErrorCallback rebalance_error_callback_;
+    Queue poll_batch_queue_;
 };
 
 } // cppkafka

--- a/src/consumer.cpp
+++ b/src/consumer.cpp
@@ -262,8 +262,11 @@ MessageList Consumer::poll_batch(size_t max_batch_size) {
 MessageList Consumer::poll_batch(size_t max_batch_size, milliseconds timeout) {
     vector<rd_kafka_message_t*> raw_messages(max_batch_size);
     // Note that this will leak the queue when using rdkafka < 0.11.5 (see get_queue comment)
-    Queue queue(get_queue(rd_kafka_queue_get_consumer(get_handle())));
-    ssize_t result = rd_kafka_consume_batch_queue(queue.get_handle() , timeout.count(), raw_messages.data(),
+    if (poll_batch_queue_.get_handle() == nullptr) {
+        poll_batch_queue_ = Queue(get_queue(rd_kafka_queue_get_consumer(get_handle())));
+    }
+    ssize_t result = rd_kafka_consume_batch_queue(poll_batch_queue_.get_handle() ,
+                                                  timeout.count(), raw_messages.data(),
                                                   raw_messages.size());
     if (result == -1) {
         check_error(rd_kafka_last_error());


### PR DESCRIPTION
Commit df04b27e226 fixed the memory leak. However, the queue is
created and destroyed every time calling the poll_batch function,
which sometimes will be hundreds of times per second. This commit
makes the queue a class member, so it can be created and destroyed
only when needed.