### PR TITLE
changed assert with if statement

### DIFF
--- a/include/cppkafka/utils/buffered_producer.h
+++ b/include/cppkafka/utils/buffered_producer.h
@@ -849,9 +849,10 @@ void BufferedProducer<BufferType>::on_delivery_report(const Message& message) {
     if (tracker) {
         tracker->should_retry_.set_value(should_retry);
     }
-    // Decrement the expected acks
-    --pending_acks_;
-    assert(pending_acks_ != (size_t)-1); // Prevent underflow
+    // Decrement the expected acks and check to prevent underflow
+    if (pending_acks_ > 0) {
+        --pending_acks_;
+    }
 }
 
 } // cppkafka


### PR DESCRIPTION
In all the testing we have done (and quite extensively) this assert happened only once. However we run debug builds in production and this assert can't happen otherwise the task crashes. I suspect, it's something to do with the underlying rdkafka library where either a message delivery callback was called twice or there was a duplicate ack from kafka, or something like that. I checked the buffered producer code and the `pending_acks_` is only incremented in a single place. It could also be that `produce()` actually sent the message but returned an error afterwards, meaning the `pending_acks_` counter was not incremented but kafka still sent an ack back. In any case, this happened only once. 