### PR TITLE
Message timestamp refactoring and log level changes

### DIFF
--- a/include/cppkafka/kafka_handle_base.h
+++ b/include/cppkafka/kafka_handle_base.h
@@ -110,7 +110,7 @@ public:
     void set_timeout(std::chrono::milliseconds timeout);
     
     /**
-     * @brief Sets the log level
+     * \brief Sets the log level
      */
      void set_log_level(LogLevel level);
 

--- a/include/cppkafka/kafka_handle_base.h
+++ b/include/cppkafka/kafka_handle_base.h
@@ -45,6 +45,7 @@
 #include "topic_configuration.h"
 #include "configuration.h"
 #include "macros.h"
+#include "logging.h"
 
 namespace cppkafka {
 
@@ -107,6 +108,11 @@ public:
      * \param timeout The timeout to be set
      */
     void set_timeout(std::chrono::milliseconds timeout);
+    
+    /**
+     * @brief Sets the log level
+     */
+     void set_log_level(LogLevel level);
 
     /**
      * \brief Adds one or more brokers to this handle's broker list

--- a/include/cppkafka/message.h
+++ b/include/cppkafka/message.h
@@ -40,10 +40,10 @@
 #include "macros.h"
 #include "error.h"
 #include "header_list.h"
+#include "message_timestamp.h"
 
 namespace cppkafka {
 
-class MessageTimestamp;
 class Internal;
 
 /**
@@ -175,7 +175,7 @@ public:
      *
      * If calling rd_kafka_message_timestamp returns -1, then boost::none_t will be returned.
      */
-    inline boost::optional<MessageTimestamp> get_timestamp() const;
+    boost::optional<MessageTimestamp> get_timestamp() const;
     
     /**
      * \brief Gets the message latency in microseconds as measured from the produce() call.
@@ -225,49 +225,6 @@ private:
 };
 
 using MessageList = std::vector<Message>;
-
-/**
- * Represents a message's timestamp
- */
-class CPPKAFKA_API MessageTimestamp {
-public:
-    /**
-     * The timestamp type
-     */
-    enum TimestampType {
-        CREATE_TIME = RD_KAFKA_TIMESTAMP_CREATE_TIME,
-        LOG_APPEND_TIME = RD_KAFKA_TIMESTAMP_LOG_APPEND_TIME
-    };
-
-    /**
-     * Constructs a timestamp object using a 'duration'.
-     */
-    MessageTimestamp(std::chrono::milliseconds timestamp, TimestampType type);
-    
-    /**
-     * Gets the timestamp value. If the timestamp was created with a 'time_point',
-     * the duration represents the number of milliseconds since epoch.
-     */
-    std::chrono::milliseconds get_timestamp() const;
-
-    /**
-     * Gets the timestamp type
-     */
-    TimestampType get_type() const;
-private:
-    std::chrono::milliseconds timestamp_;
-    TimestampType type_;
-};
-
-boost::optional<MessageTimestamp> Message::get_timestamp() const {
-    rd_kafka_timestamp_type_t type = RD_KAFKA_TIMESTAMP_NOT_AVAILABLE;
-    int64_t timestamp = rd_kafka_message_timestamp(handle_.get(), &type);
-    if (timestamp == -1 || type == RD_KAFKA_TIMESTAMP_NOT_AVAILABLE) {
-        return {};
-    }
-    return MessageTimestamp(std::chrono::milliseconds(timestamp),
-                            static_cast<MessageTimestamp::TimestampType>(type));
-}
 
 } // cppkafka
 

--- a/include/cppkafka/message_timestamp.h
+++ b/include/cppkafka/message_timestamp.h
@@ -27,42 +27,47 @@
  *
  */
 
-#ifndef CPPKAFKA_H
-#define CPPKAFKA_H
+#ifndef CPPKAFKA_MESSAGE_TIMESTAMP_H
+#define CPPKAFKA_MESSAGE_TIMESTAMP_H
 
-#include <cppkafka/buffer.h>
-#include <cppkafka/clonable_ptr.h>
-#include <cppkafka/configuration.h>
-#include <cppkafka/configuration_base.h>
-#include <cppkafka/configuration_option.h>
-#include <cppkafka/consumer.h>
-#include <cppkafka/error.h>
-#include <cppkafka/exceptions.h>
-#include <cppkafka/group_information.h>
-#include <cppkafka/header.h>
-#include <cppkafka/header_list.h>
-#include <cppkafka/header_list_iterator.h>
-#include <cppkafka/kafka_handle_base.h>
-#include <cppkafka/logging.h>
-#include <cppkafka/macros.h>
-#include <cppkafka/message.h>
-#include <cppkafka/message_builder.h>
-#include <cppkafka/message_internal.h>
-#include <cppkafka/message_timestamp.h>
-#include <cppkafka/metadata.h>
-#include <cppkafka/producer.h>
-#include <cppkafka/queue.h>
-#include <cppkafka/topic.h>
-#include <cppkafka/topic_configuration.h>
-#include <cppkafka/topic_partition.h>
-#include <cppkafka/topic_partition_list.h>
-#include <cppkafka/utils/backoff_committer.h>
-#include <cppkafka/utils/backoff_performer.h>
-#include <cppkafka/utils/buffered_producer.h>
-#include <cppkafka/utils/compacted_topic_processor.h>
-#include <cppkafka/utils/consumer_dispatcher.h>
-#include <cppkafka/utils/poll_interface.h>
-#include <cppkafka/utils/poll_strategy_base.h>
-#include <cppkafka/utils/roundrobin_poll_strategy.h>
+#include <chrono>
+#include <boost/optional.hpp>
+#include <librdkafka/rdkafka.h>
+#include "macros.h"
 
-#endif
+namespace cppkafka {
+
+/**
+ * Represents a message's timestamp
+ */
+class CPPKAFKA_API MessageTimestamp {
+    friend class Message;
+public:
+    /**
+     * The timestamp type
+     */
+    enum TimestampType {
+        CREATE_TIME = RD_KAFKA_TIMESTAMP_CREATE_TIME,
+        LOG_APPEND_TIME = RD_KAFKA_TIMESTAMP_LOG_APPEND_TIME
+    };
+    
+    /**
+     * Gets the timestamp value. If the timestamp was created with a 'time_point',
+     * the duration represents the number of milliseconds since epoch.
+     */
+    std::chrono::milliseconds get_timestamp() const;
+
+    /**
+     * Gets the timestamp type
+     */
+    TimestampType get_type() const;
+private:
+    MessageTimestamp(std::chrono::milliseconds timestamp, TimestampType type);
+    
+    std::chrono::milliseconds timestamp_;
+    TimestampType type_;
+};
+
+} // cppkafka
+
+#endif //CPPKAFKA_MESSAGE_TIMESTAMP_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCES
     buffer.cpp
     queue.cpp
     message.cpp
+    message_timestamp.cpp
     message_internal.cpp
     topic_partition.cpp
     topic_partition_list.cpp

--- a/src/consumer.cpp
+++ b/src/consumer.cpp
@@ -79,6 +79,7 @@ Consumer::Consumer(Configuration config)
     }
     rd_kafka_poll_set_consumer(ptr);
     set_handle(ptr);
+    set_log_level(LogLevel::LogErr);
 }
 
 Consumer::~Consumer() {

--- a/src/kafka_handle_base.cpp
+++ b/src/kafka_handle_base.cpp
@@ -83,6 +83,10 @@ void KafkaHandleBase::set_timeout(milliseconds timeout) {
     timeout_ms_ = timeout;
 }
 
+void KafkaHandleBase::set_log_level(LogLevel level) {
+    rd_kafka_set_log_level(handle_.get(), static_cast<int>(level));
+}
+
 void KafkaHandleBase::add_brokers(const string& brokers) {
     rd_kafka_brokers_add(handle_.get(), brokers.data());
 }

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -84,20 +84,14 @@ Message& Message::load_internal() {
     return *this;
 }
 
-// MessageTimestamp
-
-MessageTimestamp::MessageTimestamp(milliseconds timestamp, TimestampType type)
-: timestamp_(timestamp),
-  type_(type) {
-
-}
-
-milliseconds MessageTimestamp::get_timestamp() const {
-    return timestamp_;
-}
-
-MessageTimestamp::TimestampType MessageTimestamp::get_type() const {
-    return type_;
+boost::optional<MessageTimestamp> Message::get_timestamp() const {
+    rd_kafka_timestamp_type_t type = RD_KAFKA_TIMESTAMP_NOT_AVAILABLE;
+    int64_t timestamp = rd_kafka_message_timestamp(handle_.get(), &type);
+    if (timestamp == -1 || type == RD_KAFKA_TIMESTAMP_NOT_AVAILABLE) {
+        return {};
+    }
+    return MessageTimestamp(std::chrono::milliseconds(timestamp),
+                            static_cast<MessageTimestamp::TimestampType>(type));
 }
 
 } // cppkafka

--- a/src/message_timestamp.cpp
+++ b/src/message_timestamp.cpp
@@ -26,43 +26,26 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  */
+ 
+#include "message_timestamp.h"
 
-#ifndef CPPKAFKA_H
-#define CPPKAFKA_H
+using std::chrono::milliseconds;
 
-#include <cppkafka/buffer.h>
-#include <cppkafka/clonable_ptr.h>
-#include <cppkafka/configuration.h>
-#include <cppkafka/configuration_base.h>
-#include <cppkafka/configuration_option.h>
-#include <cppkafka/consumer.h>
-#include <cppkafka/error.h>
-#include <cppkafka/exceptions.h>
-#include <cppkafka/group_information.h>
-#include <cppkafka/header.h>
-#include <cppkafka/header_list.h>
-#include <cppkafka/header_list_iterator.h>
-#include <cppkafka/kafka_handle_base.h>
-#include <cppkafka/logging.h>
-#include <cppkafka/macros.h>
-#include <cppkafka/message.h>
-#include <cppkafka/message_builder.h>
-#include <cppkafka/message_internal.h>
-#include <cppkafka/message_timestamp.h>
-#include <cppkafka/metadata.h>
-#include <cppkafka/producer.h>
-#include <cppkafka/queue.h>
-#include <cppkafka/topic.h>
-#include <cppkafka/topic_configuration.h>
-#include <cppkafka/topic_partition.h>
-#include <cppkafka/topic_partition_list.h>
-#include <cppkafka/utils/backoff_committer.h>
-#include <cppkafka/utils/backoff_performer.h>
-#include <cppkafka/utils/buffered_producer.h>
-#include <cppkafka/utils/compacted_topic_processor.h>
-#include <cppkafka/utils/consumer_dispatcher.h>
-#include <cppkafka/utils/poll_interface.h>
-#include <cppkafka/utils/poll_strategy_base.h>
-#include <cppkafka/utils/roundrobin_poll_strategy.h>
+namespace cppkafka {
 
-#endif
+MessageTimestamp::MessageTimestamp(milliseconds timestamp, TimestampType type)
+: timestamp_(timestamp),
+  type_(type) {
+
+}
+
+milliseconds MessageTimestamp::get_timestamp() const {
+    return timestamp_;
+}
+
+MessageTimestamp::TimestampType MessageTimestamp::get_type() const {
+    return type_;
+}
+
+} // cppkafka
+

--- a/src/producer.cpp
+++ b/src/producer.cpp
@@ -52,8 +52,8 @@ Producer::Producer(Configuration config)
     if (!ptr) {
         throw Exception("Failed to create producer handle: " + string(error_buffer));
     }
-    rd_kafka_set_log_level(ptr, 7);
     set_handle(ptr);
+    set_log_level(LogLevel::LogErr);
 }
 
 void Producer::set_payload_policy(PayloadPolicy policy) {


### PR DESCRIPTION
Small PR including:
* Refactoring the `MessageTimestamp` into its own separate file as well as making its constructor private.
* Added the `KafkaHandleBase::set_log_level()` method.
* Set default logging level to _Error_ in both `Producer` and `Consumer` class. 

_Note that the `Producer` class was setting the level to `DEBUG` in the constructor, whereas the Consumer was not setting anything. I'm not sure if this was intentional or just an oversight. Also the `Producer` was using a hard-coded log level value...perhaps a leftover from a debugging session._