### PR TITLE
Remove setting log level in the constructor

### DIFF
--- a/src/consumer.cpp
+++ b/src/consumer.cpp
@@ -70,7 +70,6 @@ Consumer::Consumer(Configuration config)
     }
     rd_kafka_poll_set_consumer(ptr);
     set_handle(ptr);
-    set_log_level(LogLevel::LogErr);
 }
 
 Consumer::~Consumer() {

--- a/src/producer.cpp
+++ b/src/producer.cpp
@@ -53,7 +53,6 @@ Producer::Producer(Configuration config)
         throw Exception("Failed to create producer handle: " + string(error_buffer));
     }
     set_handle(ptr);
-    set_log_level(LogLevel::LogErr);
 }
 
 void Producer::set_payload_policy(PayloadPolicy policy) {


### PR DESCRIPTION
Setting the log level in the producer and consumer constructor can interfere with the user setting the `log_level` rdkafka option which essentially gets overriden to Err level. It's best to either let the user specify it via `log_level` rdkafka option or via the `KafkaHandleBase::set_log_level` api. 

As an alternative, we could check if the user has set the `log_level` option and if so, not call the `set_log_level` api. But it feels hackish. 