### PR TITLE
Header fixes and header copy considerations

### DIFF
--- a/include/cppkafka/buffer.h
+++ b/include/cppkafka/buffer.h
@@ -81,6 +81,11 @@ public:
             throw Exception("Invalid buffer configuration");
         }
     }
+    
+    template <typename Iter>
+    Buffer(const Iter first, Iter last)
+    : Buffer(&*first, std::distance(first, last)) {
+    }
 
     /**
      * Constructs a buffer from a vector

--- a/include/cppkafka/buffer.h
+++ b/include/cppkafka/buffer.h
@@ -82,6 +82,12 @@ public:
         }
     }
     
+    /**
+     * Constructs a buffer from two iterators in the range [first,last)
+     *
+     * \param first An iterator to the start of data
+     * \param last An iterator to the end of data (not included)
+     */
     template <typename Iter>
     Buffer(const Iter first, Iter last)
     : Buffer(&*first, std::distance(first, last)) {

--- a/include/cppkafka/buffer.h
+++ b/include/cppkafka/buffer.h
@@ -93,7 +93,9 @@ public:
         static_assert(sizeof(T) == sizeof(DataType), "sizeof(T) != sizeof(DataType)");
     }
 
-    // Don't allow construction from temporary vectors
+    /**
+     * Don't allow construction from temporary vectors
+     */
     template <typename T>
     Buffer(std::vector<T>&& data) = delete;
 
@@ -108,7 +110,9 @@ public:
         static_assert(sizeof(T) == sizeof(DataType), "sizeof(T) != sizeof(DataType)");
     }
 
-    // Don't allow construction from temporary arrays
+    /**
+     * Don't allow construction from temporary arrays
+     */
     template <typename T, size_t N>
     Buffer(std::array<T, N>&& data) = delete;
 
@@ -120,9 +124,11 @@ public:
      */
     Buffer(const std::string& data); 
 
-    // Don't allow construction from temporary strings
+    /**
+     * Don't allow construction from temporary strings
+     */
     Buffer(std::string&&) = delete;
-
+    
     Buffer(const Buffer&) = delete;
     Buffer(Buffer&&) = default;
     Buffer& operator=(const Buffer&) = delete;

--- a/include/cppkafka/buffer.h
+++ b/include/cppkafka/buffer.h
@@ -89,7 +89,7 @@ public:
      * \param last An iterator to the end of data (not included)
      */
     template <typename Iter>
-    Buffer(const Iter first, Iter last)
+    Buffer(const Iter first, const Iter last)
     : Buffer(&*first, std::distance(first, last)) {
     }
 

--- a/include/cppkafka/clonable_ptr.h
+++ b/include/cppkafka/clonable_ptr.h
@@ -60,8 +60,7 @@ public:
      * \param rhs The pointer to be copied
      */
     ClonablePtr(const ClonablePtr& rhs)
-    : handle_(rhs.get_cloner() ? std::unique_ptr<T, Deleter>(rhs.clone(), rhs.get_deleter()) :
-                                 std::unique_ptr<T, Deleter>(rhs.get(), rhs.get_deleter())),
+    : handle_(std::unique_ptr<T, Deleter>(rhs.clone(), rhs.get_deleter())),
       cloner_(rhs.get_cloner()) {
 
     }
@@ -73,8 +72,7 @@ public:
      */
     ClonablePtr& operator=(const ClonablePtr& rhs) {
         if (this != &rhs) {
-            handle_ = rhs.get_cloner() ? std::unique_ptr<T, Deleter>(rhs.clone(), rhs.get_deleter()) :
-                                         std::unique_ptr<T, Deleter>(rhs.get(), rhs.get_deleter());
+            handle_ = std::unique_ptr<T, Deleter>(rhs.clone(), rhs.get_deleter());
             cloner_ = rhs.get_cloner();
         }
         return *this;
@@ -130,7 +128,7 @@ private:
      * \brief Clones the internal pointer using the specified cloner function.
      */
     T* clone() const {
-        return cloner_ ? cloner_(handle_.get()) : handle_.get();
+        return cloner_ ? cloner_(get()) : get();
     }
     
     std::unique_ptr<T, Deleter> handle_;

--- a/include/cppkafka/clonable_ptr.h
+++ b/include/cppkafka/clonable_ptr.h
@@ -92,13 +92,6 @@ public:
     }
     
     /**
-     * \brief Clones the internal pointer using the specified cloner function.
-     */
-    T* clone() const {
-        return cloner_ ? cloner_(handle_.get()) : handle_.get();
-    }
-    
-    /**
      * \brief Releases ownership of the internal pointer
      */
     T* release() {
@@ -133,6 +126,13 @@ public:
         return static_cast<bool>(handle_);
     }
 private:
+    /**
+     * \brief Clones the internal pointer using the specified cloner function.
+     */
+    T* clone() const {
+        return cloner_ ? cloner_(handle_.get()) : handle_.get();
+    }
+    
     std::unique_ptr<T, Deleter> handle_;
     Cloner cloner_;
 };

--- a/include/cppkafka/clonable_ptr.h
+++ b/include/cppkafka/clonable_ptr.h
@@ -60,7 +60,7 @@ public:
      * \param rhs The pointer to be copied
      */
     ClonablePtr(const ClonablePtr& rhs)
-    : handle_(std::unique_ptr<T, Deleter>(rhs.clone(), rhs.get_deleter())),
+    : handle_(std::unique_ptr<T, Deleter>(rhs.try_clone(), rhs.get_deleter())),
       cloner_(rhs.get_cloner()) {
 
     }
@@ -72,7 +72,7 @@ public:
      */
     ClonablePtr& operator=(const ClonablePtr& rhs) {
         if (this != &rhs) {
-            handle_ = std::unique_ptr<T, Deleter>(rhs.clone(), rhs.get_deleter());
+            handle_ = std::unique_ptr<T, Deleter>(rhs.try_clone(), rhs.get_deleter());
             cloner_ = rhs.get_cloner();
         }
         return *this;
@@ -124,10 +124,7 @@ public:
         return static_cast<bool>(handle_);
     }
 private:
-    /**
-     * \brief Clones the internal pointer using the specified cloner function.
-     */
-    T* clone() const {
+    T* try_clone() const {
         return cloner_ ? cloner_(get()) : get();
     }
     

--- a/include/cppkafka/header_list.h
+++ b/include/cppkafka/header_list.h
@@ -192,7 +192,7 @@ bool operator!=(const HeaderList<HeaderType>& lhs, const HeaderList<HeaderType> 
 
 template <typename HeaderType>
 HeaderList<HeaderType> HeaderList<HeaderType>::make_non_owning(rd_kafka_headers_t* handle) {
-    return handle ? HeaderList(handle, NonOwningTag()) : HeaderList();
+    return HeaderList(handle, NonOwningTag());
 }
 
 template <typename HeaderType>
@@ -204,21 +204,19 @@ HeaderList<HeaderType>::HeaderList()
 template <typename HeaderType>
 HeaderList<HeaderType>::HeaderList(size_t reserve)
 : handle_(rd_kafka_headers_new(reserve), &rd_kafka_headers_destroy, &rd_kafka_headers_copy) {
-
+    assert(reserve);
 }
 
 template <typename HeaderType>
 HeaderList<HeaderType>::HeaderList(rd_kafka_headers_t* handle)
-: handle_(handle,
-          handle ? &rd_kafka_headers_destroy : nullptr,
-          handle ? &rd_kafka_headers_copy : nullptr) { //if we own the header list, we clone it on copy
+: handle_(handle, &rd_kafka_headers_destroy, &rd_kafka_headers_copy) { //if we own the header list, we clone it on copy
+    assert(handle);
 }
 
 template <typename HeaderType>
 HeaderList<HeaderType>::HeaderList(rd_kafka_headers_t* handle, NonOwningTag)
-: handle_(handle,
-          handle ? &dummy_deleter : nullptr,
-          nullptr) { //if we don't own the header list, we forward the handle on copy.
+: handle_(handle, &dummy_deleter, nullptr) { //if we don't own the header list, we forward the handle on copy.
+    assert(handle);
 }
 
 // Methods

--- a/include/cppkafka/header_list.h
+++ b/include/cppkafka/header_list.h
@@ -147,12 +147,6 @@ public:
     rd_kafka_headers_t* get_handle() const;
     
     /**
-     * \brief Clone the underlying header list handle.
-     * \return The handle.
-     */
-    rd_kafka_headers_t* clone_handle() const;
-    
-    /**
      * \brief Get the underlying header list handle and release its ownership.
      * \return The handle.
      * \warning After this call, the HeaderList becomes invalid.
@@ -308,11 +302,6 @@ HeaderList<HeaderType>::end() const {
 template <typename HeaderType>
 rd_kafka_headers_t* HeaderList<HeaderType>::get_handle() const {
     return handle_.get();
-}
-
-template <typename HeaderType>
-rd_kafka_headers_t* HeaderList<HeaderType>::clone_handle() const {
-    return handle_.clone();
 }
 
 template <typename HeaderType>

--- a/include/cppkafka/header_list.h
+++ b/include/cppkafka/header_list.h
@@ -306,15 +306,13 @@ bool HeaderList<HeaderType>::empty() const {
 template <typename HeaderType>
 typename HeaderList<HeaderType>::Iterator
 HeaderList<HeaderType>::begin() const {
-    return empty() ? Iterator(HeaderList<HeaderType>(), 0) :
-                     Iterator(make_non_owning(handle_.get()), 0);
+    return Iterator(*this, 0);
 }
 
 template <typename HeaderType>
 typename HeaderList<HeaderType>::Iterator
 HeaderList<HeaderType>::end() const {
-    return empty() ? Iterator(HeaderList<HeaderType>(), size()) :
-                     Iterator(make_non_owning(handle_.get()), size());
+    return Iterator(*this, size());
 }
 
 template <typename HeaderType>

--- a/include/cppkafka/header_list.h
+++ b/include/cppkafka/header_list.h
@@ -159,11 +159,6 @@ public:
      */
     explicit operator bool() const;
     
-    /**
-     * \brief Indicates if this list owns the underlying handle or not.
-     */
-    bool is_owning() const;
-    
 private:
     struct NonOwningTag { };
     static void dummy_deleter(rd_kafka_headers_t*) {}
@@ -311,11 +306,6 @@ rd_kafka_headers_t* HeaderList<HeaderType>::release_handle() {
 template <typename HeaderType>
 HeaderList<HeaderType>::operator bool() const {
     return static_cast<bool>(handle_);
-}
-
-template <typename HeaderType>
-bool HeaderList<HeaderType>::is_owning() const {
-    return handle_.get_deleter() != &dummy_deleter;
 }
 
 } //namespace cppkafka

--- a/include/cppkafka/header_list.h
+++ b/include/cppkafka/header_list.h
@@ -279,16 +279,13 @@ bool HeaderList<HeaderType>::empty() const {
 template <typename HeaderType>
 typename HeaderList<HeaderType>::Iterator
 HeaderList<HeaderType>::begin() const {
-    if (empty()) {
-        return end();
-    }
-    return Iterator(make_non_owning(handle_.get()), 0);
+    return empty() ? end() : Iterator(make_non_owning(handle_.get()), 0);
 }
 
 template <typename HeaderType>
 typename HeaderList<HeaderType>::Iterator
 HeaderList<HeaderType>::end() const {
-    return Iterator(make_non_owning(handle_.get()), size());
+    return Iterator(empty() ? HeaderList<HeaderType>() : make_non_owning(handle_.get()), size());
 }
 
 template <typename HeaderType>

--- a/include/cppkafka/header_list.h
+++ b/include/cppkafka/header_list.h
@@ -260,8 +260,7 @@ HeaderType HeaderList<HeaderType>::at(size_t index) const {
     if (error != RD_KAFKA_RESP_ERR_NO_ERROR) {
         throw Exception(error.to_string());
     }
-    //Use 'Buffer' to implicitly convert to 'BufferType'
-    return HeaderType(name, Buffer(value, size));
+    return HeaderType(name, BufferType(value, value + size));
 }
 
 template <typename HeaderType>

--- a/include/cppkafka/header_list_iterator.h
+++ b/include/cppkafka/header_list_iterator.h
@@ -154,7 +154,7 @@ private:
     HeaderIterator(HeaderListType headers,
                    size_t index)
     : header_list_(std::move(headers)),
-      header_(index == header_list_.size() ? HeaderType() : header_list_.at(index)),
+      header_(header_list_.empty() ? HeaderType() : header_list_.at(index)),
       index_(index) {
     }
     

--- a/include/cppkafka/header_list_iterator.h
+++ b/include/cppkafka/header_list_iterator.h
@@ -151,10 +151,9 @@ public:
     }
     
 private:
-    HeaderIterator(HeaderListType headers,
+    HeaderIterator(const HeaderListType& headers,
                    size_t index)
-    : header_list_(std::move(headers)),
-      header_(header_list_.empty() ? HeaderType() : header_list_.at(index)),
+    : header_list_(headers),
       index_(index) {
     }
     
@@ -169,7 +168,7 @@ private:
                                      other.get_value().get_size()));
     }
     
-    HeaderListType header_list_;
+    const HeaderListType& header_list_;
     HeaderType header_;
     size_t index_;
 };

--- a/include/cppkafka/message.h
+++ b/include/cppkafka/message.h
@@ -133,6 +133,9 @@ public:
      */
     void set_header_list(const HeaderListType& headers) {
         assert(handle_);
+        if (!headers) {
+            return; //nothing to set
+        }
         rd_kafka_headers_t* handle_copy = rd_kafka_headers_copy(headers.get_handle());
         rd_kafka_message_set_headers(handle_.get(), handle_copy);
         header_list_ = HeaderListType::make_non_owning(handle_copy);

--- a/include/cppkafka/message.h
+++ b/include/cppkafka/message.h
@@ -129,23 +129,13 @@ public:
 #if (RD_KAFKA_VERSION >= RD_KAFKA_HEADERS_SUPPORT_VERSION)
     /**
      * \brief Sets the message's header list.
-     * \note After this call, the Message will take ownership of the header list.
+     * \note This calls rd_kafka_message_set_headers.
      */
     void set_header_list(const HeaderListType& headers) {
         assert(handle_);
-        assert(!headers.is_owning());
-        rd_kafka_message_set_headers(handle_.get(), headers.get_handle());
-        header_list_ = HeaderListType::make_non_owning(headers.get_handle());
-    }
-    
-    /**
-     * \brief Sets the message's header list.
-     * \note After this call, the Message will take ownership of the header list.
-     */
-    void set_header_list(HeaderListType&& headers) {
-        assert(handle_);
-        rd_kafka_message_set_headers(handle_.get(), headers.get_handle());
-        header_list_ = HeaderListType::make_non_owning(headers.release_handle());
+        rd_kafka_headers_t* handle_copy = rd_kafka_headers_copy(headers.get_handle());
+        rd_kafka_message_set_headers(handle_.get(), handle_copy);
+        header_list_ = HeaderListType::make_non_owning(handle_copy);
     }
     
     /**

--- a/include/cppkafka/message.h
+++ b/include/cppkafka/message.h
@@ -128,6 +128,27 @@ public:
     
 #if (RD_KAFKA_VERSION >= RD_KAFKA_HEADERS_SUPPORT_VERSION)
     /**
+     * \brief Sets the message's header list.
+     * \note After this call, the Message will take ownership of the header list.
+     */
+    void set_header_list(const HeaderListType& headers) {
+        assert(handle_);
+        assert(!headers.is_owning());
+        rd_kafka_message_set_headers(handle_.get(), headers.get_handle());
+        header_list_ = HeaderListType::make_non_owning(headers.get_handle());
+    }
+    
+    /**
+     * \brief Sets the message's header list.
+     * \note After this call, the Message will take ownership of the header list.
+     */
+    void set_header_list(HeaderListType&& headers) {
+        assert(handle_);
+        rd_kafka_message_set_headers(handle_.get(), headers.get_handle());
+        header_list_ = HeaderListType::make_non_owning(headers.release_handle());
+    }
+    
+    /**
      * \brief Gets the message's header list
      */
     const HeaderListType& get_header_list() const {

--- a/include/cppkafka/message_builder.h
+++ b/include/cppkafka/message_builder.h
@@ -245,7 +245,7 @@ BasicMessageBuilder<T, C>::BasicMessageBuilder(const Message& message)
   key_(Buffer(message.get_key().get_data(), message.get_key().get_size())),
 #if (RD_KAFKA_VERSION >= RD_KAFKA_HEADERS_SUPPORT_VERSION)
   header_list_(message.get_header_list() ?
-               rd_kafka_headers_copy(message.get_header_list().get_handle()) : nullptr), //copy headers
+               HeaderListType(rd_kafka_headers_copy(message.get_header_list().get_handle())) : HeaderListType()), //copy headers
 #endif
   payload_(Buffer(message.get_payload().get_data(), message.get_payload().get_size())),
   timestamp_(message.get_timestamp() ? message.get_timestamp().get().get_timestamp() :
@@ -262,7 +262,7 @@ BasicMessageBuilder<T, C>::BasicMessageBuilder(const BasicMessageBuilder<U, V>& 
   partition_(rhs.partition()),
 #if (RD_KAFKA_VERSION >= RD_KAFKA_HEADERS_SUPPORT_VERSION)
   header_list_(rhs.header_list() ?
-               rd_kafka_headers_copy(rhs.header_list().get_handle()) : nullptr), //copy headers
+               HeaderListType(rd_kafka_headers_copy(rhs.header_list().get_handle())) : HeaderListType()), //copy headers
 #endif
   timestamp_(rhs.timestamp()),
   user_data_(rhs.user_data()),
@@ -278,7 +278,7 @@ BasicMessageBuilder<T, C>::BasicMessageBuilder(BasicMessageBuilder<U, V>&& rhs)
   partition_(rhs.partition()),
 #if (RD_KAFKA_VERSION >= RD_KAFKA_HEADERS_SUPPORT_VERSION)
   header_list_(rhs.header_list() ?
-               rhs.header_list().release_handle() : nullptr), //assume header ownership
+               HeaderListType(rhs.header_list().release_handle()) : HeaderListType()), //assume header ownership
 #endif
   timestamp_(rhs.timestamp()),
   user_data_(rhs.user_data()),

--- a/include/cppkafka/message_builder.h
+++ b/include/cppkafka/message_builder.h
@@ -70,7 +70,12 @@ public:
      */
     template <typename OtherBufferType, typename OtherConcrete>
     BasicMessageBuilder(const BasicMessageBuilder<OtherBufferType, OtherConcrete>& rhs);
+    template <typename OtherBufferType, typename OtherConcrete>
+    BasicMessageBuilder(BasicMessageBuilder<OtherBufferType, OtherConcrete>&& rhs);
 
+    /**
+     * Default copy and move constructors and assignment operators
+     */
     BasicMessageBuilder(BasicMessageBuilder&&) = default;
     BasicMessageBuilder(const BasicMessageBuilder&) = default;
     BasicMessageBuilder& operator=(BasicMessageBuilder&&) = default;
@@ -106,11 +111,13 @@ public:
 
 #if (RD_KAFKA_VERSION >= RD_KAFKA_HEADERS_SUPPORT_VERSION)
     /**
-     *  Add a header to the message
+     *  Add a header(s) to the message
      *
      * \param header The header to be used
      */
     Concrete& header(const HeaderType& header);
+    Concrete& headers(const HeaderListType& headers);
+    Concrete& headers(HeaderListType&& headers);
 #endif
     
     /**
@@ -208,10 +215,12 @@ public:
     Message::InternalPtr internal() const;
     Concrete& internal(Message::InternalPtr internal);
     
-private:
+protected:
     void construct_buffer(BufferType& lhs, const BufferType& rhs);
-    Concrete& get_concrete();
 
+private:
+    Concrete& get_concrete();
+    
     std::string topic_;
     int partition_{-1};
     BufferType key_;
@@ -234,21 +243,49 @@ template <typename T, typename C>
 BasicMessageBuilder<T, C>::BasicMessageBuilder(const Message& message)
 : topic_(message.get_topic()),
   key_(Buffer(message.get_key().get_data(), message.get_key().get_size())),
+#if (RD_KAFKA_VERSION >= RD_KAFKA_HEADERS_SUPPORT_VERSION)
+  header_list_(message.get_header_list() ?
+               rd_kafka_headers_copy(message.get_header_list().get_handle()) :
+               nullptr), //copy and assume ownership
+#endif
   payload_(Buffer(message.get_payload().get_data(), message.get_payload().get_size())),
   timestamp_(message.get_timestamp() ? message.get_timestamp().get().get_timestamp() :
                                        std::chrono::milliseconds(0)),
   user_data_(message.get_user_data()),
   internal_(message.internal()) {
+  
 }
 
 template <typename T, typename C>
 template <typename U, typename V>
 BasicMessageBuilder<T, C>::BasicMessageBuilder(const BasicMessageBuilder<U, V>& rhs)
-: topic_(rhs.topic()), partition_(rhs.partition()), timestamp_(rhs.timestamp()),
+: topic_(rhs.topic()),
+  partition_(rhs.partition()),
+#if (RD_KAFKA_VERSION >= RD_KAFKA_HEADERS_SUPPORT_VERSION)
+  header_list_(rhs.header_list() ?
+               rd_kafka_headers_copy(rhs.header_list().get_handle()) :
+               nullptr), //copy headers
+#endif
+  timestamp_(rhs.timestamp()),
   user_data_(rhs.user_data()),
   internal_(rhs.internal()) {
     get_concrete().construct_buffer(key_, rhs.key());
     get_concrete().construct_buffer(payload_, rhs.payload());
+}
+
+template <typename T, typename C>
+template <typename U, typename V>
+BasicMessageBuilder<T, C>::BasicMessageBuilder(BasicMessageBuilder<U, V>&& rhs)
+: topic_(rhs.topic()),
+  partition_(rhs.partition()),
+#if (RD_KAFKA_VERSION >= RD_KAFKA_HEADERS_SUPPORT_VERSION)
+  header_list_(rhs.header_list().release_handle()), //assume ownership
+#endif
+  timestamp_(rhs.timestamp()),
+  user_data_(rhs.user_data()),
+  internal_(rhs.internal()) {
+    get_concrete().construct_buffer(key_, std::move(rhs.key()));
+    get_concrete().construct_buffer(payload_, std::move(rhs.payload()));
 }
 
 template <typename T, typename C>
@@ -282,6 +319,18 @@ C& BasicMessageBuilder<T, C>::header(const HeaderType& header) {
         header_list_ = HeaderListType(5);
     }
     header_list_.add(header);
+    return get_concrete();
+}
+
+template <typename T, typename C>
+C& BasicMessageBuilder<T, C>::headers(const HeaderListType& headers) {
+    header_list_ = headers;
+    return get_concrete();
+}
+
+template <typename T, typename C>
+C& BasicMessageBuilder<T, C>::headers(HeaderListType&& headers) {
+    header_list_ = std::move(headers);
     return get_concrete();
 }
 #endif
@@ -410,7 +459,7 @@ C& BasicMessageBuilder<T, C>::get_concrete() {
 class MessageBuilder : public BasicMessageBuilder<Buffer, MessageBuilder> {
 public:
     using Base = BasicMessageBuilder<Buffer, MessageBuilder>;
-    using BasicMessageBuilder::BasicMessageBuilder;
+    using BasicMessageBuilder<Buffer, MessageBuilder>::BasicMessageBuilder;
 #if (RD_KAFKA_VERSION >= RD_KAFKA_HEADERS_SUPPORT_VERSION)
     using HeaderType = Base::HeaderType;
     using HeaderListType = Base::HeaderListType;
@@ -421,17 +470,21 @@ public:
     }
 
     template <typename T>
-    void construct_buffer(Buffer& lhs, const T& rhs) {
-        lhs = Buffer(rhs);
+    void construct_buffer(Buffer& lhs, T&& rhs) {
+        lhs = Buffer(std::forward<T>(rhs));
     }
     
+
     MessageBuilder clone() const {
         return std::move(MessageBuilder(topic()).
-                             key(Buffer(key().get_data(), key().get_size())).
-                             payload(Buffer(payload().get_data(), payload().get_size())).
-                             timestamp(timestamp()).
-                             user_data(user_data()).
-                             internal(internal()));
+            key(Buffer(key().get_data(), key().get_size())).
+#if (RD_KAFKA_VERSION >= RD_KAFKA_HEADERS_SUPPORT_VERSION)
+            headers(header_list()).
+#endif
+            payload(Buffer(payload().get_data(), payload().get_size())).
+            timestamp(timestamp()).
+            user_data(user_data()).
+            internal(internal()));
     }
 };
 
@@ -441,7 +494,12 @@ public:
 template <typename T>
 class ConcreteMessageBuilder : public BasicMessageBuilder<T, ConcreteMessageBuilder<T>> {
 public:
+    using Base = BasicMessageBuilder<T, ConcreteMessageBuilder<T>>;
     using BasicMessageBuilder<T, ConcreteMessageBuilder<T>>::BasicMessageBuilder;
+#if (RD_KAFKA_VERSION >= RD_KAFKA_HEADERS_SUPPORT_VERSION)
+    using HeaderType = typename Base::HeaderType;
+    using HeaderListType = typename Base::HeaderListType;
+#endif
 };
 
 } // cppkafka

--- a/src/producer.cpp
+++ b/src/producer.cpp
@@ -70,7 +70,7 @@ void Producer::produce(const MessageBuilder& builder) {
 }
 
 void Producer::produce(MessageBuilder&& builder) {
-    do_produce(builder, MessageBuilder::HeaderListType(builder.header_list().release_handle())); //move headers
+    do_produce(builder, std::move(builder.header_list())); //move headers
 }
 
 void Producer::produce(const Message& message) {

--- a/tests/buffer_test.cpp
+++ b/tests/buffer_test.cpp
@@ -39,7 +39,11 @@ TEST_CASE("construction", "[buffer]") {
     const string str_data = "Hello world!";
     const vector<uint8_t> data(str_data.begin(), str_data.end());
     const Buffer buffer(data);
+    const Buffer buffer2(data.begin(), data.end());
+    const Buffer buffer3(str_data.data(), str_data.data() + str_data.size());
     CHECK(str_data == buffer);
+    CHECK(buffer == buffer2);
+    CHECK(buffer == buffer3);
 }
 
 


### PR DESCRIPTION
### Scope of fixes
* `ClonerPtr` was not copying the cloner function on copy. Also few other helper functions were added to this class.
* `MessageBuilder` class was missing header support in a few functions which caused the feature not to work with the `BufferedProducer` class. 
* Added `BasicMessageBuilder::headers` overload to allow taking header lists as well.
* Removed asserts in the `HeaderList::iterator` access so as to allow iterating even if the list is empty. This makes the code easier. Same for `size()` and `empty()` methods which should work even if there's no header handle.
* Added set header methods in the `Message` class to support `rd_kafka_message_set_headers` API which is useful if re-producing a `Message` with different headers. (see `BasicMessageBuilder::BasicMessageBuilder(const Message&)` or `BufferedProducer::send(const Message&)` APIs)

### Current issues -- too many header copies!! 
While debugging the `BufferedProducer` I realized that the headers (if present) are being copied too many times. For instance when calling `BufferedProducer::produce(const MessageBuilder&)`:
* I create a `ConcreteMessageBuilder<string>` -> creation of headers. I can't use directly a `MessageBuilder` for architecture considerations...
* Call produce() which calls the `MessageBuilder` conversion constructor. This causes the headers to be copied once (part of the fix above).
* Inside `produce`, assuming we have internal data (optional), we clone the `MessageBuilder` class. 2nd copy. (part of the fix above)
* Then `BufferedProducer::produce_message` calls the `Producer::produce(const MessageBuilder&)` (instead of the move produce) which causes a 3rd copy. At this point the headers are moved into rdkafka which takes ownership of them. 

If the headers are small, this is probably not too much of an issue, but if the headers are large buffers, and there's multiple headers, then it becomes a bottleneck. I'm not sure how to solve this, but one idea would be to make the `MessageBuilder` class non-header-owning. This makes sense conceptually because `MessageBuilder` members are `Buffers` which by themselves are non-owning, so why would the headers be copied? This would avoid the 1st and 2nd copy and inside `Producer::produce` we can make a hard copy (i.e. calling `rd_kafka_headers_copy(MessageBuilder::header_list()::get_handle())` since the copy constructor would not work in this case as it's non-owning. 

One problem with making the `MessageBuilder` non-owning is that when calling `MessageBuilder::header` for adding an individual header, we will create underneath a header list but that list will be non-owning. This is a bit counter-intuitive. Also when calling `Producer::produce`, this will make another copy, but then who will delete the handle non-owned by the `MessageBuilder`? 
If we remove the copy inside `Producer::produce`, then if someone is building a `MessageBuilder` from a `ConcreteMessageBuilder`, that concrete class will have to `release` its internal ownership as it will be passed unto rdkafka. This is an extra manual step which will be ugly. 

I have fixed the issues but I have **not** made the proposed enhancements to the `MessageBuilder` class as I wasn't sure if you had other solutions. 