### PR TITLE
Added queue full notification

### DIFF
--- a/include/cppkafka/utils/buffered_producer.h
+++ b/include/cppkafka/utils/buffered_producer.h
@@ -146,7 +146,7 @@ public:
     using FlushTerminationCallback = std::function<void(const MessageBuilder&, Error error)>;
     
     /**
-     * Callback to indicate a queue full error was received when producing.
+     * Callback to indicate a RD_KAFKA_RESP_ERR__QUEUE_FULL was received when producing.
      *
      * The MessageBuilder instance represents the message which triggered the error. This callback will be called
      * according to the set_queue_full_notification() setting.


### PR DESCRIPTION
Added queue full notification with various triggering options. This is needed so that the application can be notified when the rdkafka queue is backed up and can be allowed to reduce upstream pressure on the producers.