### PR TITLE
Bug with message leak in BufferedProducer::flush(timeout)

### DIFF
--- a/include/cppkafka/utils/buffered_producer.h
+++ b/include/cppkafka/utils/buffered_producer.h
@@ -581,6 +581,12 @@ bool BufferedProducer<BufferType, Allocator>::flush(std::chrono::milliseconds ti
             remaining = timeout - std::chrono::duration_cast<std::chrono::milliseconds>
                 (std::chrono::high_resolution_clock::now() - start_time);
         } while (!flush_queue.empty() && (remaining.count() > 0));
+        
+        // Re-enqueue remaining messages in original order
+        if (!flush_queue.empty()) {
+            std::lock_guard<std::mutex> lock(mutex_);
+            messages_.insert(messages_.begin(), std::make_move_iterator(flush_queue.rbegin()), std::make_move_iterator(flush_queue.rend()))
+        }
     }
     else {
         async_flush();

--- a/include/cppkafka/utils/buffered_producer.h
+++ b/include/cppkafka/utils/buffered_producer.h
@@ -585,7 +585,7 @@ bool BufferedProducer<BufferType, Allocator>::flush(std::chrono::milliseconds ti
         // Re-enqueue remaining messages in original order
         if (!flush_queue.empty()) {
             std::lock_guard<std::mutex> lock(mutex_);
-            messages_.insert(messages_.begin(), std::make_move_iterator(flush_queue.rbegin()), std::make_move_iterator(flush_queue.rend()))
+            messages_.insert(messages_.begin(), std::make_move_iterator(flush_queue.begin()), std::make_move_iterator(flush_queue.end()));
         }
     }
     else {


### PR DESCRIPTION
There is currently a bug inside `BufferedProducer::flush(timeout)` where if the timeout expired before the temporary `flush_queue` is completely purged, the remaining _unsent_ messages are deleted when the function returns. The remaining messages must be re-enqueued back.

The solution could be made more performant if the `QueueType` is changed from `deque` to `list` and `list::splice()` is used instead of inserting at the front of the `deque`. However this method is not very popular (probably) and deque performs better than a list overall...so not sure if it's worth the hassle.