### PR TITLE
Added a high-priority queue to BufferedProducer to avoid message re-ordering

### DIFF
--- a/include/cppkafka/utils/buffered_producer.h
+++ b/include/cppkafka/utils/buffered_producer.h
@@ -682,7 +682,7 @@ bool BufferedProducer<BufferType, Allocator>::flush(std::chrono::milliseconds ti
             std::swap(messages_, flush_queue);
         }
         auto remaining = timeout;
-        auto start_time = std::chrono::high_resolution_clock::now();        
+        auto start_time = std::chrono::high_resolution_clock::now();
         do {
             if (!hi_pri_flush_queue.empty()) {
                 sync_produce(hi_pri_flush_queue.front());
@@ -824,7 +824,7 @@ void BufferedProducer<BufferType, Allocator>::do_add_message(BuilderType&& build
         else {
             async_flush();
         }
-    }    
+    }
 }
 
 template <typename BufferType, typename Allocator>


### PR DESCRIPTION
Currently, when a **BufferedProducer** is used, and produced messages are failed to be sent (async_produce) or failed to be delivered (on_delivery_report), then **do_add_message** will enqueue the messages to the messsages_ queue with the **MessagePriority::High** priority. However, the existing code enqueues them to the front of the queue via emplace_front. This can cause reversing the original order of messages: e.g., failing to send messages M1, M2, M3 will result in having M3, M2, M1 in messages_. So if the next attempt to flush the queue succeeds, the messages will be sent in the reverse order w.r.t. the original. This pull request adds a high-priority message queue to BufferedProducer: high-priority messages are always enqueued to the back of the queue, and this queue is always flushed before the low-priority message queue.