### PR TITLE
Use CMAKE_STATIC_LIBRARY_* macros for FindRdKafka

### DIFF
--- a/cmake/FindRdKafka.cmake
+++ b/cmake/FindRdKafka.cmake
@@ -1,16 +1,11 @@
 # Override default CMAKE_FIND_LIBRARY_SUFFIXES
+# (Allows optional prioritization of static libraries during resolution)
 if (CPPKAFKA_RDKAFKA_STATIC_LIB)
-    if (MSVC)
-        set(RDKAFKA_SUFFIX lib)
-    else()
-        set(RDKAFKA_SUFFIX a)
-    endif()
+    set(RDKAFKA_PREFIX ${CMAKE_STATIC_LIBRARY_PREFIX})
+    set(RDKAFKA_SUFFIX ${CMAKE_STATIC_LIBRARY_SUFFIX})
 else()
-    if (MSVC)
-        set(RDKAFKA_SUFFIX dll)
-    else()
-        set(RDKAFKA_SUFFIX so)
-    endif()
+    set(RDKAFKA_PREFIX ${CMAKE_SHARED_LIBRARY_PREFIX})
+    set(RDKAFKA_SUFFIX ${CMAKE_SHARED_LIBRARY_SUFFIX})
 endif()
 
 find_path(RDKAFKA_ROOT_DIR
@@ -31,7 +26,7 @@ if (CPPKAFKA_CMAKE_VERBOSE)
 endif()
 
 find_library(RDKAFKA_LIBRARY
-    NAMES rdkafka.${RDKAFKA_SUFFIX} librdkafka.${RDKAFKA_SUFFIX} rdkafka
+    NAMES ${RDKAFKA_PREFIX}rdkafka${RDKAFKA_SUFFIX} rdkafka
     HINTS ${RDKAFKA_ROOT_DIR}/lib
 )
 


### PR DESCRIPTION
In the current implementation, library suffixes are hard coded from a hand-maintained list.  Instead of writing this list, we can use the CMake macros for platform specific library prefix/suffixes.

E.g. https://cmake.org/cmake/help/v3.0/variable/CMAKE_STATIC_LIBRARY_SUFFIX.html

This also resolves library resolution on Mac OSX, which does not currently work on the native `.dylib`  suffix for shared libraries.