### PR TITLE
Added wait_for_acks(0) when calling async_flush

### DIFF
--- a/include/cppkafka/utils/buffered_producer.h
+++ b/include/cppkafka/utils/buffered_producer.h
@@ -221,7 +221,8 @@ public:
     /**
      * \brief Flushes all buffered messages and returns immediately.
      *
-     * Similar to flush, it will send all messages but will not wait for acks to complete.
+     * Similar to flush, it will send all messages but will not wait for acks to complete. However the underlying
+     * producer will still be flushed.
      */
     void async_flush();
 
@@ -641,6 +642,7 @@ void BufferedProducer<BufferType, Allocator>::async_flush() {
     };
     queue_flusher(retry_messages_, retry_mutex_);
     queue_flusher(messages_, mutex_);
+    wait_for_acks(std::chrono::milliseconds(0)); //flush the producer but don't wait
 }
 
 template <typename BufferType, typename Allocator>


### PR DESCRIPTION
This is more of an improvement, I'm actually not sure 100% it's worth doing. The rationale for the change is as follows:
* When calling `flush()`, `wait_for_acks()` which essentially calls `Producer::flush()`, is **always** called. This makes sense since we must wait for responses before proceeding. 
* When calling `async_flush()`, `wait_for_acks()` is **never** called, which means that the producer never gets flushed. It's a bit counter-intuitive that one method calls flush but not the other. 
* Inside the producer poll loop, the application must either call `flush()` or the combo `async_flush() + wait_for_acks(0)` if it wants to not block which is easy to miss for someone unfamiliar with this class, and hard to debug.

The solution is to call `wait_for_acks()` in both cases, but not block in the async version of `flush`. 