### PR TITLE
Fix FreeBSD builds

### DIFF
--- a/include/cppkafka/detail/endianness.h
+++ b/include/cppkafka/detail/endianness.h
@@ -42,11 +42,11 @@
 #   define __LITTLE_ENDIAN LITTLE_ENDIAN
 #   define __PDP_ENDIAN    PDP_ENDIAN
 
-#elif defined(__OpenBSD__)
+#elif defined(__OpenBSD__) || defined(__FreeBSD__)
 
 #   include <sys/endian.h>
 
-#elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
+#elif defined(__NetBSD__) || defined(__DragonFly__)
 
 #   include <sys/endian.h>
 


### PR DESCRIPTION
sys/endian.h already defines all the beNNtoh macros since FreeBSD 5.0,
attempts to redeclare these leads to build failure