### PR TITLE
Fix build on some libcxx implementations

### DIFF
--- a/src/topic_partition_list.cpp
+++ b/src/topic_partition_list.cpp
@@ -89,7 +89,7 @@ TopicPartitionList find_matches(const TopicPartitionList& partitions,
         for (const auto& topic : topics) {
             if (topic.size() == partition.get_topic().size()) {
                 // compare both strings
-                bool match = equal(topic.begin(), topic.end(), partition.get_topic().begin(),
+                bool match = std::equal(topic.begin(), topic.end(), partition.get_topic().begin(),
                                    [](char c1, char c2)->bool {
                     return toupper(c1) == toupper(c2);
                 });

--- a/src/topic_partition_list.cpp
+++ b/src/topic_partition_list.cpp
@@ -38,6 +38,7 @@ using std::vector;
 using std::set;
 using std::ostream;
 using std::string;
+using std::equal;
 
 namespace cppkafka {
 
@@ -89,7 +90,7 @@ TopicPartitionList find_matches(const TopicPartitionList& partitions,
         for (const auto& topic : topics) {
             if (topic.size() == partition.get_topic().size()) {
                 // compare both strings
-                bool match = std::equal(topic.begin(), topic.end(), partition.get_topic().begin(),
+                bool match = equal(topic.begin(), topic.end(), partition.get_topic().begin(),
                                    [](char c1, char c2)->bool {
                     return toupper(c1) == toupper(c2);
                 });


### PR DESCRIPTION
src/topic_partition_list.cpp:91:30: error: use of undeclared identifier 'equal'; did you mean 'std::equal'?
                bool match = equal(topic.begin(), topic.end(), partition.get_topic().begin(),
                             ^~~~~
                             std::equal
../libs/cxxsupp/libcxx/include/algorithm:1215:1: note: 'std::equal' declared here
equal(_InputIterator1 __first1, _InputIterator1 __last1, _InputIterator2 __first2, _BinaryPredicate __pred)
^
1 error generated.