### PR TITLE
Support for generating pkg-config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,10 @@ if (CPPKAFKA_RDKAFKA_STATIC_LIB)
     add_definitions("-DLIBRDKAFKA_STATICLIB")
 endif()
 
+if (NOT CPPKAFKA_PKGCONFIG_DIR)
+    set(CPPKAFKA_PKGCONFIG_DIR share/pkgconfig)
+endif()
+
 # Look for Boost (just need boost.optional headers here)
 find_package(Boost REQUIRED ${FIND_PACKAGE_QUIET})
 find_package(RdKafka REQUIRED ${FIND_PACKAGE_QUIET})

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ The following cmake options can be specified:
 * `CPPKAFKA_BOOST_STATIC_LIBS` : Link with Boost static libraries. Default is `ON`.
 * `CPPKAFKA_BOOST_USE_MULTITHREADED` : Use Boost multi-threaded libraries. Default is `ON`.
 * `CPPKAFKA_RDKAFKA_STATIC_LIB` : Link to Rdkafka static library. Default is `OFF`.
+* `CPPKAFKA_PKGCONFIG_DIR` : Install location of the .pc file. Default is `share/pkgconfig`.
 
 Example:
 ```Shell

--- a/cppkafka.pc.in
+++ b/cppkafka.pc.in
@@ -11,4 +11,4 @@ Version: @CPPKAFKA_VERSION@
 Requires: librdkafka >= 0.9.4
 Requires.private:
 Libs: -L${libdir} -L${sharedlibdir} -L@RDKAFKA_ROOT_DIR@/lib -lcppkafka -lrdkafka -lpthread -lrt -lssl -lcrypto -ldl -lz
-Cflags: -I${includedir} -I${includedir}/cppkafka -I@RDKAFKA_ROOT_DIR@/include -I@Boost_INCLUDE_DIRS@
+Cflags: -I${includedir} -I${includedir}/cppkafka -I@RDKAFKA_INCLUDE_DIR@ -I@Boost_INCLUDE_DIRS@

--- a/cppkafka.pc.in
+++ b/cppkafka.pc.in
@@ -11,4 +11,4 @@ Version: @CPPKAFKA_VERSION@
 Requires: librdkafka >= 0.9.4
 Requires.private:
 Libs: -L${libdir} -L${sharedlibdir} -L@RDKAFKA_ROOT_DIR@/lib -lcppkafka -lrdkafka -lpthread -lrt -lssl -lcrypto -ldl -lz
-Cflags: -I${includedir} -I${includedir}/cppkafka -I@RDKAFKA_ROOT_DIR@/include
+Cflags: -I${includedir} -I${includedir}/cppkafka -I@RDKAFKA_ROOT_DIR@/include -I@Boost_INCLUDE_DIRS@

--- a/cppkafka.pc.in
+++ b/cppkafka.pc.in
@@ -1,0 +1,14 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+sharedlibdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: cppkafka
+Url: https://github.com/mfontanini/cppkafka
+Description: C++ wrapper library on top of RdKafka
+Version: @CPPKAFKA_VERSION@
+Requires: librdkafka >= 0.9.4
+Requires.private:
+Libs: -L${libdir} -L${sharedlibdir} -L@RDKAFKA_ROOT_DIR@/lib -lcppkafka -lrdkafka -lpthread -lrt -lssl -lcrypto -ldl -lz
+Cflags: -I${includedir} -I${includedir}/cppkafka -I@RDKAFKA_ROOT_DIR@/include

--- a/include/cppkafka/CMakeLists.txt
+++ b/include/cppkafka/CMakeLists.txt
@@ -10,7 +10,7 @@ function(make_cppkafka_header)
     endforeach()
 
     #create file from template
-    configure_file(${PROJECT_SOURCE_DIR}/cppkafka.h.in ${CPPKAFKA_HEADER})
+    configure_file(${PROJECT_SOURCE_DIR}/cppkafka.h.in ${CPPKAFKA_HEADER} @ONLY)
 endfunction()
 
 # Run file generation function

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,7 +53,7 @@ set(PKG_CONFIG ${PROJECT_SOURCE_DIR}/package/cppkafka.pc)
 configure_file(${PROJECT_SOURCE_DIR}/cppkafka.pc.in ${PKG_CONFIG} @ONLY)
 
 install(
-    FILES PKG_CONFIG
-    DESTINATION share/pkgconfig
+    FILES ${PKG_CONFIG}
+    DESTINATION ${CPPKAFKA_PKGCONFIG_DIR}
     COMPONENT pkgconfig
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,9 +41,19 @@ endif()
 target_link_libraries(cppkafka ${DEPENDENCIES})
 target_include_directories(cppkafka PUBLIC ${PROJECT_SOURCE_DIR}/include)
 
-install( 
+install(
     TARGETS cppkafka
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib
     COMPONENT dev
+)
+
+# Generate package configuration file
+set(PKG_CONFIG ${PROJECT_SOURCE_DIR}/package/cppkafka.pc)
+configure_file(${PROJECT_SOURCE_DIR}/cppkafka.pc.in ${PKG_CONFIG} @ONLY)
+
+install(
+    FILES PKG_CONFIG
+    DESTINATION share/pkgconfig
+    COMPONENT pkgconfig
 )


### PR DESCRIPTION
Generates pkg-config file from template `cppkafka.pc.in` and outputs it into `./package/cppkafka.pc`.