### PR TITLE
Removed dependency from rdkafka since it has its own pkg_config file.…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,16 @@ option(CPPKAFKA_BOOST_STATIC_LIBS "Link with Boost static libraries." ON)
 option(CPPKAFKA_BOOST_USE_MULTITHREADED "Use Boost multithreaded libraries." ON)
 option(CPPKAFKA_RDKAFKA_STATIC_LIB "Link with Rdkafka static library." OFF)
 
+# Determine if this is a 32 or 64 bit build
+string(FIND ${CMAKE_CXX_FLAGS} "-m64" BITNESS)
+
+# Properly set the output directory
+if (${BITNESS} EQUAL -1)
+    set(LIBDIR "lib")
+else()
+    set(LIBDIR "lib64")
+endif()
+
 # Disable output from find_package macro
 if (NOT CPPKAFKA_CMAKE_VERBOSE)
     set(FIND_PACKAGE_QUIET QUIET)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,14 +38,13 @@ option(CPPKAFKA_BOOST_STATIC_LIBS "Link with Boost static libraries." ON)
 option(CPPKAFKA_BOOST_USE_MULTITHREADED "Use Boost multithreaded libraries." ON)
 option(CPPKAFKA_RDKAFKA_STATIC_LIB "Link with Rdkafka static library." OFF)
 
-# Determine if this is a 32 or 64 bit build
-string(FIND ${CMAKE_CXX_FLAGS} "-m64" BITNESS)
+math(EXPR BITS "8*${CMAKE_SIZEOF_VOID_P}")
 
 # Properly set the output directory
-if (${BITNESS} EQUAL -1)
-    set(LIBDIR "lib")
-else()
+if (${BITS} EQUAL 64)
     set(LIBDIR "lib64")
+else()
+    set(LIBDIR "lib")
 endif()
 
 # Disable output from find_package macro

--- a/cppkafka.pc.in
+++ b/cppkafka.pc.in
@@ -1,14 +1,14 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${prefix}/lib
-sharedlibdir=${prefix}/lib
+libdir=${prefix}/@LIBDIR@
+sharedlibdir=${prefix}/@LIBDIR@
 includedir=${prefix}/include
 
 Name: cppkafka
 Url: https://github.com/mfontanini/cppkafka
 Description: C++ wrapper library on top of RdKafka
 Version: @CPPKAFKA_VERSION@
-Requires: rdkafka >= 0.9.4 boost
-Requires.private:
-Libs: -L${libdir} -L${sharedlibdir} -L@RDKAFKA_ROOT_DIR@/lib -lcppkafka -lrdkafka -lpthread -lrt -lssl -lcrypto -ldl -lz
-Cflags: -I${includedir} -I${includedir}/cppkafka -I@RDKAFKA_INCLUDE_DIR@ -I@Boost_INCLUDE_DIRS@
+Requires:
+Requires.private: rdkafka >= 0.9.4, boost
+Libs: -L${libdir} -L${sharedlibdir} -lcppkafka
+Cflags: -I${includedir} -I${includedir}/cppkafka

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,8 +43,8 @@ target_include_directories(cppkafka PUBLIC ${PROJECT_SOURCE_DIR}/include)
 
 install(
     TARGETS cppkafka
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION ${LIBDIR}
+    ARCHIVE DESTINATION ${LIBDIR}
     COMPONENT dev
 )
 


### PR DESCRIPTION
**Description**
* Removed dependency from _rdkafka_ inside the `cppkafka.pc` since _rdkafka_ has its own pkg_config file and it would cause double linking which is unnecessary.
* Also added bitness detection for path installation and library search for the `cppkafka.pc` file.
* Moved dependent libs from `Requires` to `Requires.private` and added comma separation between libs.