### PR TITLE
Use GNUInstallDirs() over setting up LIBDIR manually

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
-cmake_minimum_required(VERSION 2.8.1)
+cmake_minimum_required(VERSION 2.8.5)
 project(cppkafka)
+
+include(GNUInstallDirs)
 
 # Set the version number.
 set(CPPKAFKA_VERSION_MAJOR 0)
@@ -37,15 +39,6 @@ option(CPPKAFKA_DISABLE_EXAMPLES "Disable build of cppkafka examples." OFF)
 option(CPPKAFKA_BOOST_STATIC_LIBS "Link with Boost static libraries." ON)
 option(CPPKAFKA_BOOST_USE_MULTITHREADED "Use Boost multithreaded libraries." ON)
 option(CPPKAFKA_RDKAFKA_STATIC_LIB "Link with Rdkafka static library." OFF)
-
-math(EXPR BITS "8*${CMAKE_SIZEOF_VOID_P}")
-
-# Properly set the output directory
-if (${BITS} EQUAL 64)
-    set(LIBDIR "lib64")
-else()
-    set(LIBDIR "lib")
-endif()
 
 # Disable output from find_package macro
 if (NOT CPPKAFKA_CMAKE_VERBOSE)

--- a/cppkafka.pc.in
+++ b/cppkafka.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${prefix}/@LIBDIR@
-sharedlibdir=${prefix}/@LIBDIR@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+sharedlibdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/include
 
 Name: cppkafka

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,8 +43,6 @@ target_include_directories(cppkafka PUBLIC ${PROJECT_SOURCE_DIR}/include)
 
 install(
     TARGETS cppkafka
-    LIBRARY DESTINATION ${LIBDIR}
-    ARCHIVE DESTINATION ${LIBDIR}
     COMPONENT dev
 )
 


### PR DESCRIPTION
Setting LIBDIR manually does not allow overwriting it, and for example
archlinux has /lib64 as a symlink to /lib and hence it's package manager
- pacman - will report an error during installation [1]:

    error: failed to commit transaction (conflicting files)
    cppkafka-git: /usr/lib64 exists in filesystem (owned by filesystem)

  [1]: https://aur.archlinux.org/packages/cppkafka-git/#comment-694919

While with GNUInstallDirs() you can overwrite it like this:
  cmake -DCMAKE_INSTALL_LIBDIR=lib ..