### PR TITLE
Remove boost dependency from pkg-config template file

### DIFF
--- a/cppkafka.pc.in
+++ b/cppkafka.pc.in
@@ -9,6 +9,6 @@ Url: https://github.com/mfontanini/cppkafka
 Description: C++ wrapper library on top of RdKafka
 Version: @CPPKAFKA_VERSION@
 Requires:
-Requires.private: rdkafka >= 0.9.4, boost
+Requires.private: rdkafka >= 0.9.4
 Libs: -L${libdir} -L${sharedlibdir} -lcppkafka
 Cflags: -I${includedir} -I${includedir}/cppkafka


### PR DESCRIPTION
Boost not provide pkg-config file, so if execute
 'pkg-config --exist cppkafka' command with boost dependency,
 user always gets non-zero return. And PKG_SEARCH_MODULE in cmake
 use the command to check the status of cppkafka.

The boost dependency should be removed for general usage can be works.