### PR TITLE
Added RdKafkaException base class

### DIFF
--- a/include/cppkafka/exceptions.h
+++ b/include/cppkafka/exceptions.h
@@ -51,6 +51,19 @@ private:
 };
 
 /**
+ * Base class for all rdkafka exceptions
+ */
+class CPPKAFKA_API RdKafkaException : public Exception {
+public:
+    RdKafkaException(Error error);
+    RdKafkaException(Error error, std::string message);
+    
+    Error get_error() const noexcept;
+private:
+    Error error_;
+};
+
+/**
  * A configuration related error
  */
 class CPPKAFKA_API ConfigException : public Exception {
@@ -87,7 +100,7 @@ public:
  */
 class CPPKAFKA_API ParseException : public Exception {
 public:
-    ParseException(const std::string& message);
+    ParseException(std::string message);
 };
 
 /** 
@@ -101,37 +114,25 @@ public:
 /**
  * A generic rdkafka handle error
  */
-class CPPKAFKA_API HandleException : public Exception {
+class CPPKAFKA_API HandleException : public RdKafkaException {
 public:
     HandleException(Error error);
-
-    Error get_error() const;
-private:
-    Error error_;
 };
 
 /**
  * Consumer exception
  */
-class CPPKAFKA_API ConsumerException : public Exception {
+class CPPKAFKA_API ConsumerException : public RdKafkaException {
 public:
     ConsumerException(Error error);
-
-    Error get_error() const;
-private:
-    Error error_;
 };
 
 /**
  * Queue exception for rd_kafka_queue_t errors
  */
-class CPPKAFKA_API QueueException : public Exception {
+class CPPKAFKA_API QueueException : public RdKafkaException {
 public:
     QueueException(Error error);
-
-    Error get_error() const;
-private:
-    Error error_;
 };
 
 /**
@@ -139,7 +140,7 @@ private:
  */
 class CPPKAFKA_API ActionTerminatedException : public Exception {
 public:
-    ActionTerminatedException(const std::string& error);
+    ActionTerminatedException(std::string message);
 };
 
 } // cppkafka

--- a/src/exceptions.cpp
+++ b/src/exceptions.cpp
@@ -31,6 +31,7 @@
 
 using std::string;
 using std::to_string;
+using std::move;
 
 namespace cppkafka {
 
@@ -43,6 +44,24 @@ Exception::Exception(string message)
 
 const char* Exception::what() const noexcept {
     return message_.data();
+}
+
+// RdKafkaException
+
+RdKafkaException::RdKafkaException(Error error)
+: Exception(error.to_string())
+, error_(move(error)) {
+
+}
+
+RdKafkaException::RdKafkaException(Error error, string message)
+: Exception(move(message))
+, error_(move(error)) {
+
+}
+
+Error RdKafkaException::get_error() const noexcept {
+    return error_;
 }
 
 // ConfigException
@@ -75,8 +94,8 @@ ElementNotFound::ElementNotFound(const string& element_type, const string& name)
 
 // ParseException
 
-ParseException::ParseException(const string& message)
-: Exception(message) {
+ParseException::ParseException(string message)
+: Exception(move(message)) {
 
 }
 
@@ -89,40 +108,28 @@ UnexpectedVersion::UnexpectedVersion(uint32_t version)
 // HandleException
 
 HandleException::HandleException(Error error) 
-: Exception(error.to_string()), error_(error) {
+: RdKafkaException(move(error)) {
 
-}
-
-Error HandleException::get_error() const {
-    return error_;
 }
 
 // ConsumerException
 
 ConsumerException::ConsumerException(Error error) 
-: Exception(error.to_string()), error_(error) {
+: RdKafkaException(move(error)) {
 
-}
-
-Error ConsumerException::get_error() const {
-    return error_;
 }
 
 // QueueException
 
 QueueException::QueueException(Error error)
-: Exception(error.to_string()), error_(error) {
+: RdKafkaException(move(error)) {
 
-}
-
-Error QueueException::get_error() const {
-    return error_;
 }
 
 // ActionTerminatedException
 
-ActionTerminatedException::ActionTerminatedException(const string& error) 
-: Exception(error) {
+ActionTerminatedException::ActionTerminatedException(string message)
+: Exception(move(message)) {
 
 }
     


### PR DESCRIPTION
* Added `RdKafkaException` base class for exceptions which take an `Error` as parameter. This allows for easier catching and processing of kafka-specific errors.
* In cases where the error message was sinked into the Exception (`ParseException` and `ActionTerminatedException`), the signature is _pass-by-copy_ now to be consistent with the base `Exception` class. This should not break ABI since the constructor is only called internally.