### PR TITLE
Fix crash when message handle is valid but topic is null

### DIFF
--- a/include/cppkafka/message.h
+++ b/include/cppkafka/message.h
@@ -108,7 +108,7 @@ public:
      */
     std::string get_topic() const {
         assert(handle_);
-        return rd_kafka_topic_name(handle_->rkt);
+        return handle_->rkt ? rd_kafka_topic_name(handle_->rkt) : std::string{};
     }
 
     /**


### PR DESCRIPTION
Certain RdKafka errors such as `RD_KAFKA_RESP_ERR__TIMED_OUT` when brokers are down or undiscoverable will cause RdKafka to raise the message receive callback with a valid message payload (it needs to contain the error number), however the key and partitions are null. If `Message::get_topic()` is called on such a message, this is delegated to `rd_kafka_topic_name(null)` which unfortunately dereferences this pointer w/o checking and crashes. 

@mfontanini would be great if you can prioritize this. Thanks!