### PR TITLE
Fix tracker promise from throwing when set multiple times

### DIFF
--- a/include/cppkafka/utils/buffered_producer.h
+++ b/include/cppkafka/utils/buffered_producer.h
@@ -771,7 +771,7 @@ void BufferedProducer<BufferType, Allocator>::clear() {
 
 template <typename BufferType, typename Allocator>
 size_t BufferedProducer<BufferType, Allocator>::get_buffer_size() const {
-    int size = 0;
+    size_t size = 0;
     {
         std::lock_guard<std::mutex> lock(mutex_);
         size += messages_.size();

--- a/include/cppkafka/utils/buffered_producer.h
+++ b/include/cppkafka/utils/buffered_producer.h
@@ -771,7 +771,16 @@ void BufferedProducer<BufferType, Allocator>::clear() {
 
 template <typename BufferType, typename Allocator>
 size_t BufferedProducer<BufferType, Allocator>::get_buffer_size() const {
-    return messages_.size() + retry_messages_.size();
+    int size = 0;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        size += messages_.size();
+    }
+    {
+        std::lock_guard<std::mutex> lock(retry_mutex_);
+        size += retry_messages_.size();
+    }
+    return size;
 }
 
 template <typename BufferType, typename Allocator>
@@ -1025,7 +1034,12 @@ void BufferedProducer<BufferType, Allocator>::on_delivery_report(const Message& 
     }
     // Signal producers
     if (tracker) {
-        tracker->should_retry_.set_value(should_retry);
+        try {
+            tracker->should_retry_.set_value(should_retry);
+        }
+        catch (const std::future_error& ex) {
+            //This is an async retry and future is not being read
+        }
     }
     // Decrement the expected acks and check to prevent underflow
     if (pending_acks_ > 0) {


### PR DESCRIPTION
Two issues:
* `std::deque::size()` should be guarded as it's not thread safe. The size() is computed via pointer diff (finish-start) of the queue itself and it returns garbage in a multi-threaded access scenario. 
* The tracker promise may be set multiple times if there are retries. If the produce is asynchronous, the future of this promise is never checked (and as such the promise is never re-created), which means the **same** promise can be set multiple times, throwing a `promise_already_satisfied` exception. This in itself is not an error, however it prevents the `pending_acks` from being properly decremented and the flush eventually blocks forever as the `pending_acks` mismatch. 

@mfontanini please prioritize this if you can. Much appreciated!! 