### PR TITLE
Added clarifications and comments to the BufferedProducer class

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,12 +1,34 @@
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../include/)
 include_directories(SYSTEM ${CATCH_INCLUDE})
 
-set(KAFKA_TEST_INSTANCE "kafka-vm:9092" 
+if (NOT KAFKA_TEST_INSTANCE)
+set(KAFKA_TEST_INSTANCE kafka-vm:9092
     CACHE STRING "The kafka instance to which to connect to run tests")
+endif()
+if (NOT KAFKA_NUM_PARTITIONS)
+   set(KAFKA_NUM_PARTITIONS 3 CACHE STRING "Kafka Number of partitions")
+endif()
+if (NOT KAFKA_TOPICS)
+   set(KAFKA_TOPICS "cppkafka_test1;cppkafka_test2" CACHE STRING "Kafka topics")
+endif()
+
+# Convert list of topics into a C++ initializer list
+FOREACH(TOPIC ${KAFKA_TOPICS})
+   if (NOT TOPIC_LIST)
+      set(TOPIC_LIST "\"${TOPIC}\"")
+   else()
+      set(TOPIC_LIST "${TOPIC_LIST},\"${TOPIC}\"")
+   endif()
+ENDFOREACH()
+
 add_custom_target(tests)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
-add_definitions("-DKAFKA_TEST_INSTANCE=\"${KAFKA_TEST_INSTANCE}\"")
+add_definitions(
+  "-DKAFKA_TEST_INSTANCE=\"${KAFKA_TEST_INSTANCE}\""
+  -DKAFKA_NUM_PARTITIONS=${KAFKA_NUM_PARTITIONS}
+  -DKAFKA_TOPIC_NAMES=${TOPIC_LIST}
+)
 
 add_executable(cppkafka_tests
     buffer_test.cpp
@@ -25,6 +47,6 @@ add_executable(cppkafka_tests
 )
 
 # In CMake >= 3.15 Boost::boost == Boost::headers
-target_link_libraries(cppkafka_tests cppkafka RdKafka::rdkafka Boost::boost Boost::program_options )
+target_link_libraries(cppkafka_tests cppkafka RdKafka::rdkafka Boost::boost Boost::program_options)
 add_dependencies(tests cppkafka_tests)
 add_test(cppkafka cppkafka_tests)

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -15,8 +15,7 @@ using Catch::TestCaseStats;
 using Catch::Totals;
 using Catch::Session;
 
-std::vector<std::string> KAFKA_TOPICS = {"cppkafka_test1", "cppkafka_test2"};
-int KAFKA_NUM_PARTITIONS = 3;
+std::vector<std::string> KAFKA_TOPICS = {KAFKA_TOPIC_NAMES};
 
 namespace cppkafka {
 

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -9,7 +9,6 @@
 #include "cppkafka/utils/consumer_dispatcher.h"
 
 extern const std::vector<std::string> KAFKA_TOPICS;
-extern const int KAFKA_NUM_PARTITIONS;
 
 using namespace cppkafka;
 


### PR DESCRIPTION
Added more comments and clarifications for the `BufferedProducer` class. There are also small changes namely:
* Renamed internal variable `has_internal_data_` to `enable_message_retries_` to make its intent clearer.
* Encapsulated `Tracker` logic inside the class for better expression of functionality.
* Minor typos
* Re-did a proper implementation of `flush(timeout)`. The previous function was too complicated and simply wrong because it was using the timeout parameter as a total time spent flushing instead of being passed to `wait_for_acks` which is what it was originally supposed to do. As a result, the previous implementation would stop flushing after N messages, just because the time was up, and then re-enqueuing them back which was a performance loss. The current code simplifies everything by having a _single_ implementation for `flush`. The default `flush()` with no timeout simply calls the other overload with the default producer timeout which is consistent with all other overloads in the class. An overload for `sync_produce(timeout)` was also added to facilitate all this. `sync_produce()` just redirects to `sync_produce(default_timeout)` underneath. 
* Implement `async_flush` in terms of `flush(milliseconds(0))`. The logic was identical and merging these two makes code more intuitive. 
* Implement `AckMonitor` which properly tracks acks for each thread as well as globally. This is needed in multi-threaded producers so that each producer only waits until his last ack is received. Otherwise, in the previous implementation, each producer would wait until acks from _all_ producers were received, which is unnecessary and it would slow down production.