### PR TITLE
Add RPM packaging

### DIFF
--- a/packaging/get_version.py
+++ b/packaging/get_version.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+import sys
+
+if len(sys.argv) != 2:
+    raise Exception('Usage: %s path/to/CMakeLists.txt' % sys.argv[0])
+
+cmake_lists_file = sys.argv[1]
+major = "0"
+minor = "0"
+patch = "0"
+with open(cmake_lists_file) as f:
+    for line in f:
+        if 'CPPKAFKA_VERSION_MAJOR ' in line:
+            major = line.split()[-1].replace(')', '')
+        elif 'CPPKAFKA_VERSION_MINOR ' in line:
+            minor = line.split()[-1].replace(')', '')
+        elif 'CPPKAFKA_VERSION_REVISION ' in line:
+            patch = line.split()[-1].replace(')', '')
+            break
+
+version = '.'.join(str(item) for item in (major, minor, patch))
+
+print version

--- a/packaging/rpm/Makefile
+++ b/packaging/rpm/Makefile
@@ -1,0 +1,48 @@
+PACKAGE_NAME?= cppkafka
+VERSION?=      $(shell ../get_version.py ../../CMakeLists.txt)
+BUILD_NUMBER?= 1
+MOCK_CONFIG?=  default
+RESULT_DIR?=   pkgs-$(VERSION)-$(BUILD_NUMBER)-$(MOCK_CONFIG)
+
+all: rpm
+
+SOURCES:
+	mkdir -p SOURCES
+
+archive: SOURCES
+	cd ../../ && \
+	git archive --prefix=$(PACKAGE_NAME)-$(VERSION)/ \
+		-o packaging/rpm/SOURCES/$(PACKAGE_NAME)-$(VERSION).tar.gz HEAD
+
+
+build_prepare: archive
+	mkdir -p $(RESULT_DIR)
+	rm -f $(RESULT_DIR)/$(PACKAGE_NAME)*.rpm
+
+
+srpm: build_prepare
+	/usr/bin/mock \
+		-r $(MOCK_CONFIG) \
+		--define "__version $(VERSION)" \
+		--define "__release $(BUILD_NUMBER)" \
+		--resultdir=$(RESULT_DIR) \
+		--no-clean --no-cleanup-after \
+		--buildsrpm \
+		--spec=cppkafka.spec \
+		--sources=SOURCES
+
+rpm: srpm
+	/usr/bin/mock \
+		-r $(MOCK_CONFIG) \
+		--define "__version $(VERSION)"\
+		--define "__release $(BUILD_NUMBER)"\
+		--resultdir=$(RESULT_DIR) \
+		--no-clean --no-cleanup-after \
+		--rebuild $(RESULT_DIR)/$(PACKAGE_NAME)*.src.rpm
+
+copy-artifacts:
+	cp $(RESULT_DIR)/*rpm ../../artifacts/
+
+clean:
+	rm -rf SOURCES
+	/usr/bin/mock -r $(MOCK_CONFIG) --clean

--- a/packaging/rpm/cppkafka.spec
+++ b/packaging/rpm/cppkafka.spec
@@ -1,0 +1,62 @@
+Name:    cppkafka
+Version: %{__version}
+Release: %{__release}%{?dist}
+
+Summary: Modern C++ Apache Kafka client library (wrapper for librdkafka)
+Group:   Development/Libraries/C and C++
+License: BSD-2-Clause
+URL:     https://github.com/mfontanini/cppkafka
+Source:  %{name}-%{version}.tar.gz
+
+BuildRequires: librdkafka-devel cmake g++ boost-devel openssl-devel zlib-devel
+
+%description
+Modern C++ Apache Kafka client library (wrapper for librdkafka)
+
+%package devel
+Summary:        Development files for %{name}
+Group:          Development/Libraries/C and C++
+Requires:       %{name} = %{version}
+
+%description devel
+This package contains headers and libraries required to build applications
+using cppkafka.
+
+%global debug_package %%{nil}
+
+%prep
+%setup
+
+%build
+cd $RPM_BUILD_DIR
+mkdir build
+cd build
+cmake -DCMAKE_INSTALL_PREFIX=%{_prefix} \
+      $RPM_BUILD_DIR/%{name}-%{version}
+make -j$(nproc)
+
+%install
+cd $RPM_BUILD_DIR/build
+DESTDIR=%{buildroot} make install
+
+%clean
+rm -rf %{buildroot}
+
+%post -p /sbin/ldconfig
+%postun -p /sbin/ldconfig
+
+%pre
+%preun
+
+%files
+%{_libdir}/lib%{name}*.so.*
+
+%files devel
+%{_libdir}/lib%{name}*.so*
+%{_libdir}/../lib/cmake/CppKafka/*
+%{_includedir}/%{name}
+%{_datadir}/pkgconfig
+
+%changelog
+* Fri Feb 21 2020 Adam Fowles <adam.fowles@eagleview.com> 0.3.1-0
+- Initial RPM package


### PR DESCRIPTION
Adding packaging support in the style of librdkafka. In order to use third party software in our build process we need to be able to package it to avoid building from source each time. If you care to have this here it is. 