### PR TITLE
Bring base class  resume into scope

### DIFF
--- a/include/cppkafka/consumer.h
+++ b/include/cppkafka/consumer.h
@@ -102,6 +102,7 @@ public:
     using RevocationCallback = std::function<void(const TopicPartitionList&)>;
     using RebalanceErrorCallback = std::function<void(Error)>;
     using KafkaHandleBase::pause;
+    using KafkaHandleBase::resume;
 
     /**
      * \brief Creates an instance of a consumer.


### PR DESCRIPTION
Bring base class `resume()` member function into the scope of `Consumer`. This was missing since `pause` is already into scope.