### PR TITLE
Fix CMAKE warning

### DIFF
--- a/cmake/FindRdKafka.cmake
+++ b/cmake/FindRdKafka.cmake
@@ -39,7 +39,7 @@ if (CPPKAFKA_CMAKE_VERBOSE)
 endif()
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(RDKAFKA DEFAULT_MSG
+find_package_handle_standard_args(RdKafka DEFAULT_MSG
     RdKafka_LIBNAME
     RdKafka_LIBRARY_PATH
     RdKafka_INCLUDE_DIR


### PR DESCRIPTION
Fixes the following warning:
```
The package name passed to `find_package_handle_standard_args` (RDKAFKA)
  does not match the name of the calling package (RdKafka).  This can lead to
  problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.
```