### PR TITLE
remove unused boost includes

### DIFF
--- a/include/cppkafka/message_timestamp.h
+++ b/include/cppkafka/message_timestamp.h
@@ -31,7 +31,6 @@
 #define CPPKAFKA_MESSAGE_TIMESTAMP_H
 
 #include <chrono>
-#include <boost/optional.hpp>
 #include <librdkafka/rdkafka.h>
 #include "macros.h"
 

--- a/include/cppkafka/queue.h
+++ b/include/cppkafka/queue.h
@@ -29,7 +29,6 @@
 
 #include <vector>
 #include <memory>
-#include <boost/optional.hpp>
 #include <librdkafka/rdkafka.h>
 #include "event.h"
 #include "macros.h"

--- a/include/cppkafka/topic.h
+++ b/include/cppkafka/topic.h
@@ -32,7 +32,6 @@
 
 #include <string>
 #include <memory>
-#include <boost/optional.hpp>
 #include <librdkafka/rdkafka.h>
 #include "macros.h"
 

--- a/include/cppkafka/utils/buffered_producer.h
+++ b/include/cppkafka/utils/buffered_producer.h
@@ -39,7 +39,6 @@
 #include <atomic>
 #include <future>
 #include <thread>
-#include <boost/optional.hpp>
 #include "../producer.h"
 #include "../detail/callback_invoker.h"
 #include "../message_internal.h"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,6 +47,6 @@ add_executable(cppkafka_tests
 )
 
 # In CMake >= 3.15 Boost::boost == Boost::headers
-target_link_libraries(cppkafka_tests cppkafka RdKafka::rdkafka Boost::boost Boost::program_options)
+target_link_libraries(cppkafka_tests cppkafka RdKafka::rdkafka Boost::boost)
 add_dependencies(tests cppkafka_tests)
 add_test(cppkafka cppkafka_tests)


### PR DESCRIPTION
small cleanup of boost/optional includes as well as an unnecessary linkage of the tests target with boost/program_options.