### PR TITLE
Add fix for in-source build of cppkafka.h.

### DIFF
--- a/include/cppkafka/CMakeLists.txt
+++ b/include/cppkafka/CMakeLists.txt
@@ -1,7 +1,8 @@
+set(CPPKAFKA_HEADER "${CMAKE_CURRENT_BINARY_DIR}/cppkafka.h")
+
 # Local function to auto-generate main cppkafka.h header file
 function(make_cppkafka_header)
-    set(CPPKAFKA_HEADER ${CMAKE_CURRENT_SOURCE_DIR}/cppkafka.h)
-    file(GLOB INCLUDE_HEADERS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*.h" "utils/*.h")
+    file(GLOB INCLUDE_HEADERS RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "*.h" "utils/*.h")
     list(SORT INCLUDE_HEADERS)
     foreach(header ${INCLUDE_HEADERS})
         if (NOT ${header} MATCHES "cppkafka.h")
@@ -10,7 +11,7 @@ function(make_cppkafka_header)
     endforeach()
 
     #create file from template
-    configure_file(${PROJECT_SOURCE_DIR}/cmake/cppkafka.h.in ${CPPKAFKA_HEADER} @ONLY)
+    configure_file("${PROJECT_SOURCE_DIR}/cmake/cppkafka.h.in" "${CPPKAFKA_HEADER}" @ONLY)
 endfunction()
 
 # Run file generation function
@@ -22,7 +23,7 @@ file(GLOB UTILS_INCLUDE_FILES "utils/*.h")
 file(GLOB DETAIL_INCLUDE_FILES "detail/*.h")
 install(
     FILES ${INCLUDE_FILES}
-    DESTINATION include/cppkafka
+    DESTINATION include/cppkafka/
     COMPONENT Headers
 )
 install(
@@ -33,5 +34,10 @@ install(
 install(
     FILES ${DETAIL_INCLUDE_FILES}
     DESTINATION include/cppkafka/detail/
+    COMPONENT Headers
+)
+install(
+    FILES "${CPPKAFKA_HEADER}"
+    DESTINATION include/cppkafka/
     COMPONENT Headers
 )


### PR DESCRIPTION
This fixes an issue where `cppkafka.h` is being generated directly within the source directory, which causes issues on sandboxed build environments where the source directory is mounted readonly.

This PR changes the `configure_file()` directive to point to the cmake binary directory, and uses the install directives to move the generated file into the build output.

I also added quoting around constructed file paths that could ostensibly include spaces, to prevent any list parsing issues.