### PR TITLE
Incremental cooperative rebalancing

### DIFF
--- a/include/cppkafka/consumer.h
+++ b/include/cppkafka/consumer.h
@@ -197,6 +197,20 @@ public:
     void unassign();
     
     /**
+     * \brief Sets the current topic/partition incremental assignment
+     *
+     * This translates into a call to rd_kafka_incremental_assign
+     */
+    void incremental_assign(const TopicPartitionList& topic_partitions);
+
+    /**
+     * \brief Unassigns the current topic/partition incremental assignment
+     *
+     * This translates into a call to rd_kafka_incremental_unassign.
+     */
+    void incremental_unassign(const TopicPartitionList& topic_partitions);
+
+    /**
      * \brief Pauses all consumption
      */
     void pause();

--- a/include/cppkafka/kafka_handle_base.h
+++ b/include/cppkafka/kafka_handle_base.h
@@ -38,7 +38,9 @@
 #include <mutex>
 #include <tuple>
 #include <chrono>
+#include <librdkafka/rdtypes.h>
 #include <librdkafka/rdkafka.h>
+#include <librdkafka/rdkafka_error.h>
 #include "group_information.h"
 #include "topic_partition.h"
 #include "topic_partition_list.h"
@@ -364,6 +366,8 @@ protected:
     void set_handle(rd_kafka_t* handle);
     void check_error(rd_kafka_resp_err_t error) const;
     void check_error(rd_kafka_resp_err_t error,
+                     const rd_kafka_topic_partition_list_t* list_ptr) const;
+    void check_error(rd_kafka_error_t* error,
                      const rd_kafka_topic_partition_list_t* list_ptr) const;
     rd_kafka_conf_t* get_configuration_handle();
 private:

--- a/src/consumer.cpp
+++ b/src/consumer.cpp
@@ -29,6 +29,7 @@
 #include <sstream>
 #include <algorithm>
 #include <cctype>
+#include <cstring>
 #include "macros.h"
 #include "consumer.h"
 #include "exceptions.h"
@@ -132,6 +133,21 @@ void Consumer::assign(const TopicPartitionList& topic_partitions) {
 void Consumer::unassign() {
     rd_kafka_resp_err_t error = rd_kafka_assign(get_handle(), nullptr);
     check_error(error);
+}
+
+void Consumer::incremental_assign(const TopicPartitionList& topic_partitions) {
+    if (topic_partitions.empty()) {
+        return;
+    }
+    TopicPartitionsListPtr topic_list_handle = convert(topic_partitions);
+    rd_kafka_error_t* error = rd_kafka_incremental_assign(get_handle(), topic_list_handle.get());
+    check_error(error, topic_list_handle.get());
+}
+
+void Consumer::incremental_unassign(const TopicPartitionList& topic_partitions) {
+    TopicPartitionsListPtr topic_list_handle = convert(topic_partitions);
+    rd_kafka_error_t* error = rd_kafka_incremental_unassign(get_handle(), topic_list_handle.get());
+    check_error(error, topic_list_handle.get());
 }
 
 void Consumer::pause() {
@@ -317,11 +333,19 @@ void Consumer::handle_rebalance(rd_kafka_resp_err_t error,
                                 TopicPartitionList& topic_partitions) {
     if (error == RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS) {
         CallbackInvoker<AssignmentCallback>("assignment", assignment_callback_, this)(topic_partitions);
-        assign(topic_partitions);
+        if (!strcmp(rd_kafka_rebalance_protocol(get_handle()), "COOPERATIVE")) {
+            incremental_assign(topic_partitions);
+        } else {
+            assign(topic_partitions);
+        }
     }
     else if (error == RD_KAFKA_RESP_ERR__REVOKE_PARTITIONS) {
         CallbackInvoker<RevocationCallback>("revocation", revocation_callback_, this)(topic_partitions);
-        unassign();
+        if (!strcmp(rd_kafka_rebalance_protocol(get_handle()), "COOPERATIVE")) {
+            incremental_unassign(topic_partitions);
+        } else {
+            unassign();
+        }
     }
     else {
         CallbackInvoker<RebalanceErrorCallback>("rebalance error", rebalance_error_callback_, this)(error);

--- a/src/kafka_handle_base.cpp
+++ b/src/kafka_handle_base.cpp
@@ -281,6 +281,16 @@ void KafkaHandleBase::check_error(rd_kafka_resp_err_t error,
     }
 }
 
+void KafkaHandleBase::check_error(rd_kafka_error_t* error,
+                                  const rd_kafka_topic_partition_list_t* list_ptr) const {
+    if (!error) {
+        return;
+    }
+    rd_kafka_resp_err_t error_code = error->code;
+    rd_kafka_error_destroy(error);
+    check_error(error_code, list_ptr);
+}
+
 rd_kafka_conf_t* KafkaHandleBase::get_configuration_handle() {
     return config_.get_handle();
 }


### PR DESCRIPTION
Hello.

I created this (hopefully) small PR not to get it merged but to receive comments about my use case. I hope I don't write in the wrong place. I have an issue and I am exploring three hypotheses to explain it:
- I'm using cppkafka incorrectly.
- Something is not ok with librdkafka.
- Our Kafka broker coordinator is misconfigured and I should check with the staff who administers it.

At my job, as part of a project, we are tasked with adding support for incremental cooperative rebalancing in cppkafka. I built cppkafka from this PR against librdkafka v1.6.1 (yes it's an old version but it's a constraint at my job). I performed the following 2 tests:
- In the 1st test, I had 1 Kafka topic with 18 partitions and 1 consumer in a consumer group. Then another consumer joined this group. In the end, nothing happened, i.e. the 1st consumer went on receiving messages from 18 partitions while the 2nd consumer got no messages (bad).
- In the 2nd test, 2 Kafka topics were set up, each with 18 partitions. I had 2 consumers in a consumer group. After taking one consumer offline, the remaining consumer ended up receiving messages from 36 partitions (good).

There is no such odd behavior when switching to the roundrobin rebalancing strategy.

My question is: am I doing anything wrong with cppkafka? 

I hope I clearly and concisely stated the problem I have been encountering and am thankful for any help.

Note: in order to make cppkafka build, I had to copy a couple of librdkafka headers manually, namely rdtypes.h and rdkafka_error.h. Indeed the external header generated by librdkafka after performing `./configure && make && make install` does not export enough information.