### PR TITLE
cmake: Use CMAKE_INSTALL_LIBDIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ option(CPPKAFKA_EXPORT_CMAKE_CONFIG "Generate CMake config, target and version f
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
 
 if (NOT CPPKAFKA_CONFIG_DIR)
-    set(CPPKAFKA_CONFIG_DIR lib/cmake/${PROJECT_NAME})
+    set(CPPKAFKA_CONFIG_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
 endif()
 
 # Maintain previous compatibility


### PR DESCRIPTION
Do not hardcode library path, this helps it install in right location
independent of platforms, e.g. ppc64 uses lib64 and not lib

Signed-off-by: Khem Raj <raj.khem@gmail.com>