### PR TITLE
Fix the destruction order of handle & destroy_flags

### DIFF
--- a/include/cppkafka/kafka_handle_base.h
+++ b/include/cppkafka/kafka_handle_base.h
@@ -391,8 +391,8 @@ private:
     Configuration config_;
     TopicConfigurationMap topic_configurations_;
     std::mutex topic_configurations_mutex_;
-    HandlePtr handle_;
     int destroy_flags_;
+    HandlePtr handle_;
 };
 
 } // cppkafka

--- a/src/kafka_handle_base.cpp
+++ b/src/kafka_handle_base.cpp
@@ -48,7 +48,7 @@ namespace cppkafka {
 const milliseconds KafkaHandleBase::DEFAULT_TIMEOUT{1000};
 
 KafkaHandleBase::KafkaHandleBase(Configuration config) 
-: timeout_ms_(DEFAULT_TIMEOUT), config_(move(config)), handle_(nullptr, HandleDeleter(this)), destroy_flags_(0) {
+: timeout_ms_(DEFAULT_TIMEOUT), config_(move(config)), destroy_flags_(0), handle_(nullptr, HandleDeleter(this)) {
     auto& maybe_config = config_.get_default_topic_configuration();
     if (maybe_config) {
         maybe_config->set_as_opaque();


### PR DESCRIPTION
The MemorySanitizer detected a use-of-uninitialized-value issue caused by the destruction order in KafkaHandleBase. Specifically, the deleter of the Kafka handle accessed `destroy_flags_` after it had been destroyed because `destroy_flags_` was declared after `handle_`.

This commit reorders the member declarations so that `destroy_flags_` is declared before `handle_`. The constructor's initializer list is also updated accordingly to match the new declaration order.