### PR TITLE
Fix tests build on modern glibc by disabling Catch2 POSIX signals

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,9 @@
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../include/)
 include_directories(SYSTEM ${CATCH_INCLUDE})
 
+# Disable Catch2 POSIX signal handling (breaks on modern glibc where SIGSTKSZ is not constexpr)
+add_compile_definitions(CATCH_CONFIG_NO_POSIX_SIGNALS)
+
 if (NOT KAFKA_TEST_INSTANCE)
 set(KAFKA_TEST_INSTANCE kafka-vm:9092
     CACHE STRING "The kafka instance to which to connect to run tests")


### PR DESCRIPTION
Fixes a build failure in the test suite on systems with modern glibc (>= 2.34).

Catch2 v2 uses `SIGSTKSZ` as a compile-time constant, but newer glibc versions no longer guarantee this, causing compilation errors like:

Related issues:
https://github.com/mfontanini/cppkafka/issues/294
https://github.com/redpanda-data/redpanda/issues/4298

Tested both on ubuntu 20.04 (old glibc, build worked already) and 24.04 (new glibc, tests build failed)